### PR TITLE
Add Docker Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ language: python
 services:
   - docker
 
-before_install:
+install:
   - docker build -t lowerquality/gentle .
+
+script:
   - docker run --rm lowerquality/gentle sh -c "cd /gentle && ./tests/e2e_test.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: required
+
+language: python
+
+services:
+  - docker
+
+before_install:
+  - docker build -t lowerquality/gentle .
+  - docker run --rm lowerquality/gentle sh -c "cd /gentle && ./tests/e2e_test.sh"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:15.04
+
+ADD . /gentle
+RUN DEBIAN_FRONTEND=noninteractive cd /gentle && ./install_deps.sh && apt-get clean
+RUN cd /gentle && ./install_kaldi.sh && make
+RUN cd /gentle && ./install_models.sh
+RUN cd /gentle && make
+
+EXPOSE 8765
+
+CMD cd /gentle && python serve.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ADD . /gentle
 RUN MAKEFLAGS=' -j8' cd /gentle && \
 	./install_kaldi.sh && \
 	make
-RUN ./install_models.sh
+RUN cd /gentle && ./install_models.sh
 
 EXPOSE 8765
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,16 @@
 FROM ubuntu:15.04
 
+RUN DEBIAN_FRONTEND=noninteractive && \
+	apt-get update && \
+	apt-get install -y zlib1g-dev automake autoconf git \
+		libtool subversion libatlas3-base ffmpeg python-pip \
+		python-dev wget unzip && \
+	apt-get clean
 ADD . /gentle
-RUN DEBIAN_FRONTEND=noninteractive cd /gentle && ./install_deps.sh && apt-get clean
-RUN cd /gentle && ./install_kaldi.sh && make
-RUN cd /gentle && ./install_models.sh
-RUN cd /gentle && make
+RUN MAKEFLAGS=' -j8' cd /gentle && \
+	./install_kaldi.sh && \
+	make
+RUN ./install_models.sh
 
 EXPOSE 8765
 

--- a/dependencies_ubuntu.sh
+++ b/dependencies_ubuntu.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-sudo apt-get install -y zlib1g-dev automake autoconf git \
+apt-get update
+apt-get install -y zlib1g-dev automake autoconf git \
 	libtool subversion libatlas3-base ffmpeg python-pip
 
-sudo pip install .
+pip install .

--- a/gentle/language_model_transcribe.py
+++ b/gentle/language_model_transcribe.py
@@ -43,7 +43,7 @@ if __name__=='__main__':
         description='Align a transcript to audio by generating a new language model.')
     parser.add_argument('--proto_langdir', default="PROTO_LANGDIR",
                        help='path to the prototype language directory')
-    parser.add_argument('--nnet_dir', default="data",
+    parser.add_argument('--nnet_dir', default="data/nnet_a_gpu_online",
                        help='path to the kaldi neural net model directory')
     parser.add_argument('audio_file', help='input audio file in any format supported by FFMPEG')
     parser.add_argument('input_file', type=argparse.FileType('r'),

--- a/install.sh
+++ b/install.sh
@@ -1,31 +1,8 @@
 #!/bin/bash
 
-# Install OS-specific dependencies
-if [[ "$OSTYPE" == "linux-gnu" ]]; then
-	sh dependencies_ubuntu.sh
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-    sh dependencies_osx.sh
-fi
+set -e
 
-# Build Kaldi
-cd kaldi/tools
-make # -j 8
-cd ../src
-./configure --static --static-math=yes --static-fst=yes --use-cuda=no
-make depend # -j 8
-cd ../../
-
-# Build "standard_kaldi" python wrapper
+./install_deps.sh
+./install_kaldi.sh
 make
-
-# Download models
-wget http://lowerquality.com/gentle/kaldi-models-0.02.zip
-unzip kaldi-models-0.02.zip
-
-# Update nnet model config files
-cd data
-for x in nnet_a_gpu_online/conf/*conf; do
-    cp $x $x.orig
-    sed s:/Users/rmo/data/speech-data/:$(pwd)/: < $x.orig > $x
-done
-cd ..
+./install_models.sh

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+echo "Installing dependencies..."
+
+# Install OS-specific dependencies
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+	apt-get update
+	apt-get install -y zlib1g-dev automake autoconf git \
+		libtool subversion libatlas3-base ffmpeg python-pip \
+		python-dev wget unzip
+
+	pip install .
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+	brew install ffmpeg libtool automake autoconf wget
+
+	sudo easy_install pip
+	sudo pip install .
+fi

--- a/install_kaldi.sh
+++ b/install_kaldi.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Prepare Kaldi
+cd kaldi/tools
+make # -j 8
+cd ../src
+./configure --static --static-math=yes --static-fst=yes --use-cuda=no
+make depend # -j 8
+cd ../../

--- a/install_models.sh
+++ b/install_models.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+# Download models
+wget http://lowerquality.com/gentle/kaldi-models-0.02.zip
+unzip kaldi-models-0.02.zip
+
+# Update nnet model config files
+cd data
+for x in nnet_a_gpu_online/conf/*conf; do
+    cp $x $x.orig
+    sed s:/Users/rmo/data/speech-data/:$(pwd)/: < $x.orig > $x
+done
+cd ..

--- a/serve.py
+++ b/serve.py
@@ -61,7 +61,7 @@ class Uploader(Resource):
                             transcript,
                             # XXX
                             'PROTO_LANGDIR',
-                            'data')
+                            'data/nnet_a_gpu_online')
 
         # Save output to JSON and CSV
         json.dump({

--- a/tests/e2e_test.sh
+++ b/tests/e2e_test.sh
@@ -12,7 +12,7 @@ cd "$DIR/.."
 
 echo "Running test..."
 
-TMPDIR=$(mktemp -dt "gentle_test")
+TMPDIR=$(mktemp -dt "gentle_test_XXX")
 
 ERR=$(python gentle/language_model_transcribe.py tests/data/lucier.mp3 tests/data/lucier.txt $TMPDIR/got.json 2>&1)
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
Add a Dockerfile that builds everything and runs the web service by default

Just run this:

```
docker build -t lowerquality/gentle .
docker run -p 8765:8765 lowerquality/gentle 
```

It also adds a [Travis CI](https://travis-ci.org) build that will automatically build everything from scratch tell us if our tests failed. If you have a chance try logging into Travis and enabling the build.

We should also register for the Docker hub and publish a stable image when when hit 1.0. That will make installation as easy as typing `docker run -p 8765:8765 lowerquality/gentle` for people already running Docker.