### PR TITLE
Formalize standard_kaldi RPC

### DIFF
--- a/ext/standard_kaldi.cc
+++ b/ext/standard_kaldi.cc
@@ -234,34 +234,68 @@ void Decoder::Finalize() {
   this->decoder_.FinalizeDecoding();
 }
 
-// MarshalHypothesis serializes a Hypothesis struct into the funky text
-// format we use to communicate with the Python code.
+// MarshalPhones serializes a list of phonemes as JSON
+std::string MarshalPhones(const vector<Phoneme> &phones) {
+  std::stringstream ss;
+
+  ss << "[";
+  for (int i = 0; i < phones.size(); i++) {
+    Phoneme phone = phones[i];
+    ss << "{" << std::endl;
+
+    ss << "\"phone\":\"" << phone.token << "\",";
+    if (phone.has_duration) {
+      ss << "\"duration\":" << phone.duration;
+    }
+
+    ss << "}";
+    if (i < phones.size() - 1) {
+      ss << ",";
+    }
+  }
+  ss << "]";
+
+  return ss.str();
+}
+
+// MarshalHypothesis serializes a Hypothesis struct as JSON
 std::string MarshalHypothesis(const Hypothesis& hypothesis) {
   std::stringstream ss;
 
+  Hypothesis no_eps;
   for (AlignedWord word : hypothesis) {
     if (word.token == "<eps>") {
       // Don't output anything for <eps> links, which correspond to silence....
       continue;
     }
+    no_eps.push_back(word);
+  }
 
-    ss << "word: " << word.token;
+  ss << "{\"hypothesis\":";
+  ss << "[";
+
+  for (int i = 0; i < no_eps.size(); i++) {
+    AlignedWord word = no_eps[i];
+
+    ss << "{";
+
+    ss << "\"word\":\"" << word.token << "\",";
     if (word.has_start) {
-      ss << " / start: " << word.start;
+      ss << "\"start\":" << word.start << ",";
     }
     if (word.has_duration) {
-      ss << " / duration: " << word.duration;
+      ss << "\"duration\":" << word.duration << ",";
     }
-    ss << std::endl;
+    ss << "\"phones\":" << MarshalPhones(word.phones);
 
-    for (Phoneme phone : word.phones) {
-      ss << "phone: " << phone.token;
-      if (phone.has_duration) {
-        ss << " / duration: " << phone.duration;
-      }
-      ss << std::endl;
+    ss << "}";
+    if (i < no_eps.size() - 1) {
+      ss << ",";
     }
   }
+
+  ss << "]";
+  ss << "}" << std::endl;
 
   return ss.str();
 }

--- a/ext/standard_kaldi.cc
+++ b/ext/standard_kaldi.cc
@@ -235,7 +235,7 @@ void Decoder::Finalize() {
 }
 
 // MarshalPhones serializes a list of phonemes as JSON
-std::string MarshalPhones(const vector<Phoneme> &phones) {
+std::string MarshalPhones(const vector<Phoneme>& phones) {
   std::stringstream ss;
 
   ss << "[";

--- a/ext/standard_kaldi.cc
+++ b/ext/standard_kaldi.cc
@@ -136,20 +136,19 @@ Hypothesis Hypothesizer::GetFull(const kaldi::Lattice& lattice) {
 // Decoder represents an in-progress transcription of an utterance.
 class Decoder {
  public:
-  Decoder(
-      const kaldi::OnlineNnet2FeaturePipelineInfo& info,
-      const kaldi::TransitionModel& transition_model,
-      const kaldi::OnlineNnet2DecodingConfig& nnet2_decoding_config,
-      const kaldi::nnet2::AmNnet& nnet,
-      const fst::Fst<fst::StdArc>* decode_fst,
-      const kaldi::OnlineIvectorExtractorAdaptationState &adaptation_state);
+  Decoder(const kaldi::OnlineNnet2FeaturePipelineInfo& info,
+          const kaldi::TransitionModel& transition_model,
+          const kaldi::OnlineNnet2DecodingConfig& nnet2_decoding_config,
+          const kaldi::nnet2::AmNnet& nnet,
+          const fst::Fst<fst::StdArc>* decode_fst,
+          const kaldi::OnlineIvectorExtractorAdaptationState& adaptation_state);
 
   // AddChunk adds an audio chunk of audio to the decoding pipeline.
   void AddChunk(kaldi::BaseFloat sampling_rate,
-                      const kaldi::VectorBase<kaldi::BaseFloat>& waveform);
+                const kaldi::VectorBase<kaldi::BaseFloat>& waveform);
   // GetAdaptationState gets the ivector extractor's adaptation state
   void GetAdaptationState(
-    kaldi::OnlineIvectorExtractorAdaptationState *adaptation_state);
+      kaldi::OnlineIvectorExtractorAdaptationState* adaptation_state);
   // GetBestPath outputs the decoder's current one-best lattice.
   kaldi::Lattice GetBestPath();
   // Finalize is called when you're finished adding chunks. It flushes the
@@ -171,12 +170,13 @@ class Decoder {
   bool finalized_;
 };
 
-Decoder::Decoder(const kaldi::OnlineNnet2FeaturePipelineInfo& info,
-                 const kaldi::TransitionModel& transition_model,
-                 const kaldi::OnlineNnet2DecodingConfig& nnet2_decoding_config,
-                 const kaldi::nnet2::AmNnet& nnet,
-                 const fst::Fst<fst::StdArc>* decode_fst,
-                 const kaldi::OnlineIvectorExtractorAdaptationState &adaptation_state)
+Decoder::Decoder(
+    const kaldi::OnlineNnet2FeaturePipelineInfo& info,
+    const kaldi::TransitionModel& transition_model,
+    const kaldi::OnlineNnet2DecodingConfig& nnet2_decoding_config,
+    const kaldi::nnet2::AmNnet& nnet,
+    const fst::Fst<fst::StdArc>* decode_fst,
+    const kaldi::OnlineIvectorExtractorAdaptationState& adaptation_state)
     : feature_pipeline_(info),
       decoder_(nnet2_decoding_config,
                transition_model,
@@ -188,9 +188,8 @@ Decoder::Decoder(const kaldi::OnlineNnet2FeaturePipelineInfo& info,
   this->feature_pipeline_.SetAdaptationState(adaptation_state);
 }
 
-void Decoder::AddChunk(
-    kaldi::BaseFloat sampling_rate,
-    const kaldi::VectorBase<kaldi::BaseFloat>& waveform) {
+void Decoder::AddChunk(kaldi::BaseFloat sampling_rate,
+                       const kaldi::VectorBase<kaldi::BaseFloat>& waveform) {
   if (finalized_) {
     return;
   }
@@ -200,7 +199,7 @@ void Decoder::AddChunk(
 }
 
 void Decoder::GetAdaptationState(
-    kaldi::OnlineIvectorExtractorAdaptationState *adaptation_state) {
+    kaldi::OnlineIvectorExtractorAdaptationState* adaptation_state) {
   this->feature_pipeline_.GetAdaptationState(adaptation_state);
 }
 
@@ -267,7 +266,6 @@ std::string MarshalHypothesis(const Hypothesis& hypothesis) {
   return ss.str();
 }
 
-
 void ConfigFeatureInfo(kaldi::OnlineNnet2FeaturePipelineInfo& info,
                        std::string ivector_model_dir) {
   // online_nnet2_decoding.conf
@@ -317,6 +315,91 @@ void ConfigEndpoint(kaldi::OnlineEndpointConfig& config) {
 
 void usage() {
   fprintf(stderr, "usage: standard_kaldi nnet_dir hclg_path proto_lang_dir\n");
+}
+
+// The status codes used by the RPC. Maps to HTTP status codes.
+enum {
+  STATUS_OK = 200,
+  STATUS_BAD_REQUEST = 400,
+  STATUS_INTERNAL_SERVER_ERROR = 500
+} RPCStatus;
+
+// Parse the method part of an RPC request. Returns false if the data is
+// malformed.
+//
+// Methods have this form:
+//   METHOD <ARG1> <ARG2> ... <ARGN>\n
+bool RPCReadMethod(std::istream& stream, string* method, vector<string>* args) {
+  std::string line;
+  if (!std::getline(stream, line)) {
+    return false;
+  }
+  std::stringstream ss(line);
+
+  if (!(ss >> *method)) {
+    return false;
+  }
+
+  string buf;
+  while (ss >> buf) {
+    args->push_back(buf);
+  }
+
+  return true;
+}
+
+// Parse the body part of an RPC request. Returns false if the data is
+// malformed.
+//
+// Bodies have this form:
+//   BODY_SIZE\n
+//   BODY\n
+bool RPCReadBody(std::istream& stream, vector<char>* body) {
+  string line;
+  if (!std::getline(stream, line)) {
+    return false;
+  }
+  std::stringstream ss(line);
+
+  size_t body_size;
+  if (!(ss >> body_size)) {
+    return false;
+  }
+
+  body->resize(body_size);
+  if (!stream.read(&body->front(), body_size)) {
+    return false;
+  }
+
+  char trailing_newline;
+  if (!stream.get(trailing_newline)) {
+    return false;
+  }
+
+  return true;
+}
+
+// Write the reply part of the RPC.
+//
+// Replies have this form:
+//   STATUS\n
+//   BODY_SIZE\n
+//   BODY\n
+void RPCWriteReply(std::ostream& stream,
+                   const int& status,
+                   const vector<char>& body) {
+  stream << status << std::endl;
+  stream << body.size() << std::endl;
+  stream.write(&body[0], body.size());
+  stream << std::endl;
+}
+
+// Write the reply part of the RPC. Same as the above but accepts strings.
+void RPCWriteReply(std::ostream& stream,
+                   const int& status,
+                   const string& body_str) {
+  vector<char> body(body_str.begin(), body_str.end());
+  RPCWriteReply(stream, status, body);
 }
 
 int main(int argc, char* argv[]) {
@@ -374,7 +457,8 @@ int main(int argc, char* argv[]) {
   fst::SymbolTable* phone_syms =
       fst::SymbolTable::ReadText(phone_syms_rxfilename);
 
-  std::cerr << "Loaded!\n";
+  OnlineSilenceWeighting silence_weighting(
+      trans_model, feature_info.silence_weighting_config);
 
   Hypothesizer hypothesizer(frame_shift, trans_model, word_boundary_info,
                             word_syms, phone_syms);
@@ -386,80 +470,79 @@ int main(int argc, char* argv[]) {
                                                nnet2_decoding_config, nnet,
                                                decode_fst, adaptation_state));
 
-  char cmd[1024];
+  std::ostream& out_stream = std::cout;
+  std::istream& in_stream = std::cin;
 
-  while (fgets(cmd, sizeof(cmd), stdin)) {
-    if (strcmp(cmd, "stop\n") == 0) {
-      // Quit the program.
-      break;
+  RPCWriteReply(out_stream, STATUS_OK, "loaded");
+
+  while (!in_stream.eof()) {
+    string method;
+    vector<string> args;
+    vector<char> body;
+
+    if (!RPCReadMethod(in_stream, &method, &args)) {
+      RPCWriteReply(out_stream, STATUS_BAD_REQUEST,
+                    "malformed method '" + method + "'");
+      continue;
+    }
+    if (!RPCReadBody(in_stream, &body)) {
+      RPCWriteReply(out_stream, STATUS_BAD_REQUEST, "malformed body");
+      continue;
     }
 
-    else if (strcmp(cmd, "reset\n") == 0) {
-      // Reset all decoding state.
-      //
-      // =Reply=
-      // 1. No reply
-      decoder.reset(new Decoder(feature_info, trans_model,
-                                nnet2_decoding_config, nnet, decode_fst,
-                                adaptation_state));
-    } else if (strcmp(cmd, "push-chunk\n") == 0) {
-      // Add a chunk of audio to the decoding pipeline.
-      //
-      // =Request=
-      // 1. chunk size in bytes (as ascii string)
-      // 2. newline
-      // 3. binary data as signed 16bit integer pcm
-      // =Reply=
-      // 1. "ok\n" upon completion
-      {
-        char chunk_len_str[100];
-        fgets(chunk_len_str, sizeof(chunk_len_str), stdin);
-        int chunk_len = atoi(chunk_len_str);
+    try {
+      if (method == "stop") {
+        RPCWriteReply(out_stream, STATUS_OK, "goodbye");
+        return 0;
 
-        std::vector<char> audio_chunk(chunk_len, 0);
-        std::cin.read(&audio_chunk[0], chunk_len);
+      } else if (method == "reset") {
+        // Reset all decoding state.
+        decoder.reset(new Decoder(feature_info, trans_model,
+                                  nnet2_decoding_config, nnet, decode_fst,
+                                  adaptation_state));
+        RPCWriteReply(out_stream, STATUS_OK, "");
 
-        int sample_count = chunk_len / 2;
+      } else if (method == "push-chunk") {
+        // Add a chunk of audio to the decoding pipeline.
+        int sample_count = body.size() / 2;
 
         Vector<BaseFloat> wave_part(sample_count);
         for (int i = 0; i < sample_count; i++) {
-          int16_t sample = *reinterpret_cast<int16_t*>(&audio_chunk[i * 2]);
+          int16_t sample = *reinterpret_cast<int16_t*>(&body[i * 2]);
           wave_part(i) = sample;
         }
 
         decoder->AddChunk(arate, wave_part);
+        RPCWriteReply(out_stream, STATUS_OK, "");
 
-        fprintf(stdout, "ok\n");
+      } else if (method == "get-partial") {
+        // Dump the provisional (non-word-aligned) transcript for the current
+        // lattice.
+
+        kaldi::Lattice partial_lat = decoder->GetBestPath();
+        Hypothesis partial = hypothesizer.GetPartial(partial_lat);
+        string serialized = MarshalHypothesis(partial);
+
+        RPCWriteReply(out_stream, STATUS_OK, serialized);
+
+      } else if (method == "get-final") {
+        // Dump the final, phone-aligned transcript for the current lattice.
+        kaldi::Lattice final_lat = decoder->GetBestPath();
+        Hypothesis final = hypothesizer.GetFull(final_lat);
+        string serialized = MarshalHypothesis(final);
+
+        RPCWriteReply(out_stream, STATUS_OK, serialized);
+
+      } else {
+        RPCWriteReply(out_stream, STATUS_BAD_REQUEST, "unknown method");
+        continue;
       }
-    } else if (strcmp(cmd, "get-partial\n") == 0) {
-      // Dump the provisional (non-word-aligned) transcript for
-      // the current lattice.
-      //
-      // =Reply=
-      // 1. "word: " for every word
-      // 2. "ok\n" on completion
-      kaldi::Lattice partial_lat = decoder->GetBestPath();
-      Hypothesis partial = hypothesizer.GetPartial(partial_lat);
-      std::cout << MarshalHypothesis(partial);
-      fprintf(stdout, "ok\n");
-    } else if (strcmp(cmd, "get-final\n") == 0) {
-      // Dump the final, phone-aligned transcript for the
-      // current lattice.
-      //
-      // =Reply=
-      // 1. "phone: / duration:" for every phoneme
-      // 2. "word: / start: / duration:" for every word
-      // 3. "ok\n" on completion
-      decoder->Finalize();
-      kaldi::Lattice final_lat = decoder->GetBestPath();
-      Hypothesis final = hypothesizer.GetFull(final_lat);
-      std::cout << MarshalHypothesis(final);
-      fprintf(stdout, "ok\n");
-    } else {
-      fprintf(stdout, "unknown command\n");
+
+    } catch (const std::exception& e) {
+      RPCWriteReply(out_stream, STATUS_INTERNAL_SERVER_ERROR, e.what());
+      continue;
     }
   }
 
-  std::cerr << "Goodbye.\n";
   return 0;
 }

--- a/gentle/language_model_transcribe.py
+++ b/gentle/language_model_transcribe.py
@@ -37,6 +37,7 @@ def lm_transcribe_progress(audio_f, transcript, proto_langdir, nnet_dir):
     ks = ms.get_kaldi_sequence()
 
     gen_hclg_filename = language_model.make_bigram_language_model(ks, proto_langdir)
+    k = None
     try:
         k = standard_kaldi.Kaldi(nnet_dir, gen_hclg_filename, proto_langdir)
 
@@ -48,7 +49,8 @@ def lm_transcribe_progress(audio_f, transcript, proto_langdir, nnet_dir):
                 "words": ret,
             }
     finally:
-        k.stop()
+        if k:
+            k.stop()
         os.unlink(gen_hclg_filename)
 
 def _normal_transcribe(audio_f, proto_langdir, nnet_dir):

--- a/gentle/rpc.py
+++ b/gentle/rpc.py
@@ -1,0 +1,71 @@
+class RPCProtocol(object):
+    '''RPCProtocol is the wire protocol we use to communicate with the
+    standard_kaldi subprocess. It's a mixed text/binary protocol
+    because we need to send binary audio chunks, but text is simpler.'''
+
+    def __init__(self, send_pipe, recv_pipe):
+        '''Initializes the RPCProtocol and reads from recv_pipe until the startup
+        message is received.'''
+        self.send_pipe = send_pipe
+        self.recv_pipe = recv_pipe
+
+        # wait for startup
+        body, _ = self._read_reply()
+        if body != 'loaded':
+            raise RuntimeError('unexpected message from standard_kaldi on load')
+
+    def do(self, method, *args, **kwargs):
+        '''Performs the method requested and returns the response body.
+        The body keyword argument can be used to provide a binary request
+        body. Throws an RPCError when the RPC returns an error.'''
+        body = kwargs.get('body', None)
+        self._write_request(method, args, body)
+        return self._read_reply()
+
+    def _write_request(self, method, args, body):
+        '''Writes a request to the stream.
+        Request format:
+        METHOD <ARG1> <ARG2> ... <ARGN>\n
+        BODY_SIZE\n
+        BODY\n
+        '''
+        args_string = ' '.join(args)
+
+        try:
+            self.send_pipe.write('%s %s\n' % (method, args_string))
+            if body:
+                self.send_pipe.write('%d\n' % len(body))
+                self.send_pipe.write(body)
+            else:
+                self.send_pipe.write('0\n')
+            self.send_pipe.write('\n')
+        except IOError, _:
+            raise IOError("Lost connection with standard_kaldi subprocess")
+
+    def _read_reply(self):
+        '''Reads a reply from the stream.
+        Reply format:
+        STATUS\n
+        BODY_SIZE\n
+        BODY\n
+        '''
+        try:
+            status = int(self.recv_pipe.readline())
+            body_size = int(self.recv_pipe.readline())
+            body = self.recv_pipe.read(body_size)
+            self.recv_pipe.read(1) # trailing newline
+        except IOError, _:
+            raise IOError("Lost connection with standard_kaldi subprocess")
+
+        if status < 200 or status >= 300:
+            raise RPCError(status, body)
+
+        return body, status
+
+class RPCError(Exception):
+    '''Error thrown when standard_kaldi returns an error (in-band)'''
+    def __init__(self, status, why):
+        self.status = status
+        self.why = why
+    def __str__(self):
+        return 'standard_kaldi: error %d: %s' % (self.status, self.why)

--- a/gentle/standard_kaldi.py
+++ b/gentle/standard_kaldi.py
@@ -5,8 +5,9 @@ import subprocess
 import wave
 import tempfile
 
-from gentle.paths import get_binary
 from gentle import ffmpeg, prons
+from gentle.paths import get_binary
+from gentle.rpc import RPCProtocol
 
 EXECUTABLE_PATH = get_binary("ext/standard_kaldi")
 
@@ -31,55 +32,30 @@ class Kaldi(object):
         self._words = None
         self._stopped = False
 
-    def _write(self, data):
-        """Send data to the subprocess, print stderr and raise if it crashes"""
-        if self._stopped:
-            # TODO(maxhawkins): I don't like how this API self-destructs after
-            # use. The subprocess should stay open until the user specifically
-            # deletes it.
-            raise RuntimeError('wrote to stopped standard_kaldi process')
-        try:
-            self._subprocess.stdin.write(data)
-        except IOError, _:
-            raise IOError("Lost connection with standard_kaldi subprocess")
-
-    def _cmd(self, name):
-        """Begin a command"""
-        self._write("%s\n" % (name))
-        self._subprocess.stdin.flush()
+        self.rpc = RPCProtocol(self._subprocess.stdin, self._subprocess.stdout)
 
     def push_chunk(self, buf):
         '''Push a chunk of audio. Returns true if it worked OK.'''
-        # Wait until we're ready
-        self._cmd("push-chunk")
-        self._write("%d\n" % len(buf))
-        self._write(buf)
-        status = self._subprocess.stdout.readline().strip()
-        return status == 'ok'
+        self.rpc.do('push-chunk', body=buf)
 
     def get_partial(self):
         '''Dump the provisional (non-word-aligned) transcript'''
-        self._cmd("get-partial")
+        body, _ = self.rpc.do('get-partial')
+
         words = []
-        while True:
-            line = self._subprocess.stdout.readline()
-            logging.info("partial: %s", line)
-            if line.startswith("ok"):
-                break
-            if parts[0].startswith('word'):
-                word = parts[0].split(': ')[1]
-                words.append(word)
+        for line in body.split('\n'):
+            parts = line.split(' / ')
+            word = parts[0].split(': ')[1]
+            words.append(word)
+
         return words.join(" ")
 
     def get_final(self):
         '''Dump the final, phone-aligned transcript'''
-        self._cmd("get-final")
+        body, _ = self.rpc.do('get-final')
+
         words = []
-        while True:
-            line = self._subprocess.stdout.readline()
-            logging.info(line)
-            if line.startswith("ok"):
-                break
+        for line in body.split('\n'):
             parts = line.split(' / ')
             if parts[0].startswith('word'):
                 word = {}
@@ -101,14 +77,11 @@ class Kaldi(object):
 
     def reset(self):
         '''Reset the decoder, delete the decoding state'''
-        self._cmd("reset")
+        self.rpc.do('reset')
 
     def stop(self):
         '''Quit the program'''
-        logging.info('stopping...')
-        self._cmd("stop")
-        self._subprocess.wait()
-        logging.info('stopped\n')
+        self.rpc.do('stop')
         self._stopped = True
 
     def transcribe(self, infile):

--- a/gentle/standard_kaldi.py
+++ b/gentle/standard_kaldi.py
@@ -3,7 +3,6 @@ import json
 import logging
 import os
 import subprocess
-import tempfile
 import wave
 
 from gentle import ffmpeg, prons
@@ -174,7 +173,6 @@ def read_wav(infile):
 def main():
     '''Transcribe the given input file using a standard_kaldi C++ subprocess.'''
     import sys
-    import json
 
     infile = sys.argv[1]
     outfile = sys.argv[2]


### PR DESCRIPTION
I'm writing a Go frontend to standard_kaldi for another project. I noticed the communication protocol between Python and C++ is inconsistent in some places. This patch makes it easier to write new clients (and maintain the Python one) by formalizing the protocol.

Pushing a 5-byte chunk would look like this...

Request:
```
push-chunk
5
xxxxx

```

Reply:
```
200
2
OK
```

The protocol also allows for parameters to be supplied to each method. This will allow for more options if we add new methods. For example:

```
new-language-model model-name
9999
model-contents...
```

This also closes #63 because exceptions are caught and returned in-band.