### PR TITLE
Run ext/install_kaldi.sh from the ext directory

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,6 @@ git submodule init
 git submodule update
 
 ./install_deps.sh
-cd ext && ./install_kaldi.sh
+(cd ext && ./install_kaldi.sh)
 ./install_models.sh
 cd ext && make depend && make

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,6 @@ git submodule init
 git submodule update
 
 ./install_deps.sh
-./ext/install_kaldi.sh
+cd ext && ./install_kaldi.sh
 ./install_models.sh
 cd ext && make depend && make


### PR DESCRIPTION
The installation was getting an error:

    ./ext/install_kaldi.sh: line 4: cd: kaldi/tools: No such file or directory

Making this change seems to fix things