### PR TITLE
Add disfluency transcription during forced-alignment

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -44,6 +44,12 @@
         padding: 10px 30px;
         cursor: pointer;
       }
+      #alignment-flags {
+        background: #CCC;
+        border: 0;
+        font-size: 18px;
+        padding: 10px 30px;
+      }
       #footer {
         margin-top: 100px;
         border-top: 1px dotted black;
@@ -63,6 +69,8 @@
       <br>
       Transcript:<br>
       <textarea name="transcript"></textarea><br>
+      <input id=alignment-flags name=conservative type=checkbox> Conservative<br>
+      <input id=alignment-flags name=disfluency type=checkbox> Include disfluencies<br>
       <input id="align-button" type=submit value=Align>
     </form>
     <div id="footer">

--- a/www/view_alignment.html
+++ b/www/view_alignment.html
@@ -260,6 +260,9 @@ function render(ret) {
     wds.forEach(function(wd) {
         if(wd['case'] == 'not-found-in-transcript') {
             // TODO: show phonemes somewhere
+            var txt = ' ' + wd.word;
+            var $plaintext = document.createTextNode(txt);
+            $trans.appendChild($plaintext);
             return;
         }
 


### PR DESCRIPTION
PR to add options for transcription and injection of out-of-transcript disfluencies into gentle's forced-alignment output. Modifications include:
- Add UI toggle to handle the transcription of disfluencies during forced alignment 
- Add UI toggle to perform "conservative" forced alignment
- Add hook to interleave disfluency tokens into bigram model construction
- Add rule to render out-of-transcript disfluency tokens in forced-alignment viewer

Edit: The UI toggles are not essential and can be removed if you don't want to expose this functionality at the UI-level yet :-)