### PR TITLE
gitignore build products (ext/*.o and ext/.depend.mk)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ data/
 ext/standard_kaldi
 ext/mkgraph
 ext/*-test
+ext/*.o
+ext/.depend.mk
 *.pyc
 *~
 webdata/


### PR DESCRIPTION
After installing (on OS X),  a handful of generated files appear as untracked in git:

> 
	ext/.depend.mk
	ext/decoder.o
	ext/hypothesis.o
	ext/hypothesizer.o
	ext/mkgraph.o
	ext/rpc.o
	ext/standard_kaldi.o

This PR adds `ext/*.o` and `ext/.depend.mk` to the `.gitignore` file