### PR TITLE
Bug fix: Handle unequal-length ranges in `by_word` iterator.

### DIFF
--- a/gentle/diff_align.py
+++ b/gentle/diff_align.py
@@ -97,8 +97,16 @@ def by_word(opcodes):
             for i in range(s2, e2):
                 yield (op, s1, s1, i, i+1)
         else:
+            len1 = e1-s1
+            len2 = e2-s2
             for i1, i2 in zip(range(s1, e1), range(s2, e2)):
                 yield (op, i1, i1 + 1, i2, i2 + 1)
+            if len1 > len2:
+                for i in range(s1 + len2, e1):
+                    yield ('delete', i, i+1, e2, e2)
+            if len2 > len1:
+                for i in range(s2 + len1, e2):
+                    yield ('insert', s1, s1, i, i+1)
 
 if __name__=='__main__':
     TEXT_FILE = sys.argv[1]


### PR DESCRIPTION
The `by_word` iterator takes the result of `difflib.SequenceMatcher.get_opcodes()` and expands it into an opcode sequence that only modifies one word at a time.   

The code uses `for i1, i2 in zip(range(s1, e1), range(s2, e2))` to expand a “replace” opcode.  But in the case where the ranges have different lengths, `zip()` uses the smaller range, resulting in some words getting dropped from the expansion.

The fix here is to check for that case, and add `’delete’` or `’insert’` operations for the words that weren’t included in the zip.

Fixes #101