### PR TITLE
Remove overlap when merging chunk transcriptions

### DIFF
--- a/gentle/__init__.py
+++ b/gentle/__init__.py
@@ -3,3 +3,4 @@ from resources import Resources
 from forced_aligner import ForcedAligner
 from full_transcriber import FullTranscriber
 from resample import resample, resampled
+from transcription import Transcription

--- a/gentle/forced_aligner.py
+++ b/gentle/forced_aligner.py
@@ -3,7 +3,8 @@ from gentle import kaldi_queue
 from gentle import language_model
 from gentle import metasentence
 from gentle import multipass
-from gentle.transcription import MultiThreadedTranscriber, Transcription
+from gentle.transcriber import MultiThreadedTranscriber
+from gentle.transcription import Transcription
 
 class ForcedAligner():
 
@@ -31,7 +32,7 @@ class ForcedAligner():
 
         # Perform a second-pass with unaligned words
         if logging is not None:
-            logging.info("%d unaligned words (of %d)" % (len([X for X in words if X.get("case") == "not-found-in-audio"]), len(words)))
+            logging.info("%d unaligned words (of %d)" % (len([X for X in words if X.case == "not-found-in-audio"]), len(words)))
 
         if progress_cb is not None:
             progress_cb({'status': 'ALIGNING'})
@@ -39,6 +40,6 @@ class ForcedAligner():
         words = multipass.realign(wavfile, words, self.ms, resources=self.resources, nthreads=self.nthreads, progress_cb=progress_cb)
 
         if logging is not None:
-            logging.info("after 2nd pass: %d unaligned words (of %d)" % (len([X for X in words if X.get("case") == "not-found-in-audio"]), len(words)))
+            logging.info("after 2nd pass: %d unaligned words (of %d)" % (len([X for X in words if X.case == "not-found-in-audio"]), len(words)))
 
         return Transcription(words=words, transcript=self.transcript)

--- a/gentle/full_transcriber.py
+++ b/gentle/full_transcriber.py
@@ -1,7 +1,9 @@
 import os
 
 from gentle import kaldi_queue
-from gentle.transcription import MultiThreadedTranscriber, Transcription
+from gentle import transcription
+from gentle.transcriber import MultiThreadedTranscriber
+from gentle.transcription import Transcription
 
 class FullTranscriber():
 
@@ -24,17 +26,17 @@ class FullTranscriber():
         transcript = ""
         words = []
         for t_wd in trans:
-            word = {
-                "case": "success",
-                "startOffset": len(transcript),
-                "endOffset": len(transcript) + len(t_wd["word"]),
-                "word": t_wd["word"],
-                "alignedWord": t_wd["word"],
-                "phones": t_wd["phones"],
-                "start": t_wd["start"],
-                "end": t_wd["start"] + t_wd["duration"]}
+            word = transcription.Word(
+                case="success",
+                startOffset=len(transcript),
+                endOffset=len(transcript) + len(t_wd.word),
+                word=t_wd.word,
+                alignedWord=t_wd.word,
+                phones=t_wd.phones,
+                start=t_wd.start,
+                end=t_wd.start + t_wd.duration)
             words.append(word)
 
-            transcript += word["word"] + " "
+            transcript += word.word + " "
 
         return Transcription(words=words, transcript=transcript)

--- a/gentle/standard_kaldi.py
+++ b/gentle/standard_kaldi.py
@@ -6,7 +6,6 @@ import subprocess
 import tempfile
 import wave
 
-from gentle import ffmpeg
 from util.paths import get_binary
 from gentle.rpc import RPCProtocol
 from gentle.resources import Resources

--- a/gentle/transcriber.py
+++ b/gentle/transcriber.py
@@ -49,13 +49,19 @@ class MultiThreadedTranscriber:
         chunks.sort(key=lambda x: x['start'])
 
         # Combine chunks
-        # TODO: remove overlap? ...or just let the sequence aligner deal with it.
         words = []
         for c in chunks:
             chunk_start = c['start']
             for wd in c['words']:
                 wd['start'] += chunk_start
                 words.append(transcription.Word(**wd))
+
+        # Remove overlap:  Sort by time, then filter out any Word entries in
+        # the list that are adjacent to another entry corresponding to the same
+        # word in the audio.
+        words.sort(key=lambda word: word.start)
+        words.append(transcription.Word(word="__dummy__"))
+        words = [words[i] for i in range(len(words)-1) if not words[i].corresponds(words[i+1])]
 
         return words
 

--- a/gentle/transcriber.py
+++ b/gentle/transcriber.py
@@ -1,0 +1,84 @@
+import math
+import logging
+import wave
+
+from gentle import transcription
+
+from multiprocessing.pool import ThreadPool as Pool
+
+class MultiThreadedTranscriber:
+    def __init__(self, kaldi_queue, chunk_len=20, overlap_t=2, nthreads=4):
+        self.chunk_len = chunk_len
+        self.overlap_t = overlap_t
+        self.nthreads = nthreads
+            
+        self.kaldi_queue = kaldi_queue
+
+    def transcribe(self, wavfile, progress_cb=None):
+        wav_obj = wave.open(wavfile, 'r')
+        duration = wav_obj.getnframes() / float(wav_obj.getframerate())
+        n_chunks = int(math.ceil(duration / float(self.chunk_len - self.overlap_t)))
+
+        chunks = []
+
+        def transcribe_chunk(idx):
+            wav_obj = wave.open(wavfile, 'r')
+            start_t = idx * (self.chunk_len - self.overlap_t)
+            # Seek
+            wav_obj.setpos(int(start_t * wav_obj.getframerate()))
+            # Read frames
+            buf = wav_obj.readframes(int(self.chunk_len * wav_obj.getframerate()))
+
+            k = self.kaldi_queue.get()
+            k.push_chunk(buf)
+            ret = k.get_final()
+            k.reset()
+            self.kaldi_queue.put(k)
+
+            chunks.append({"start": start_t, "words": ret})
+            logging.info('%d/%d' % (len(chunks), n_chunks))
+            if progress_cb is not None:
+                progress_cb({"message": ' '.join([X['word'] for X in ret]),
+                             "percent": len(chunks) / float(n_chunks)})
+
+
+        pool = Pool(min(n_chunks, self.nthreads))
+        pool.map(transcribe_chunk, range(n_chunks))
+        pool.close()
+        
+        chunks.sort(key=lambda x: x['start'])
+
+        # Combine chunks
+        # TODO: remove overlap? ...or just let the sequence aligner deal with it.
+        words = []
+        for c in chunks:
+            chunk_start = c['start']
+            for wd in c['words']:
+                wd['start'] += chunk_start
+                words.append(transcription.Word(**wd))
+
+        return words
+
+
+if __name__=='__main__':
+    # full transcription
+    from Queue import Queue
+    from util import ffmpeg
+    from gentle import standard_kaldi
+
+    import sys
+
+    import logging
+    logging.getLogger().setLevel('INFO')
+    
+    k_queue = Queue()
+    for i in range(3):
+        k_queue.put(standard_kaldi.Kaldi())
+
+    trans = MultiThreadedTranscriber(k_queue)
+
+    with gentle.resampled(sys.argv[1]) as filename:
+        out = trans.transcribe(filename)
+
+    open(sys.argv[2], 'w').write(out.to_json())
+

--- a/gentle/transcription.py
+++ b/gentle/transcription.py
@@ -29,6 +29,11 @@ class Word:
     def __repr__(self):
         return "Word(" + " ".join(sorted([key + "=" + str(val) for key, val in self.as_dict().iteritems()])) + ")"
 
+    def corresponds(self, other):
+        '''Returns true if self and other refer to the same word, at the same position in the audio (within a small tolerance)'''
+        if self.word != other.word: return False
+        return abs(self.start - other.start) / (self.duration + other.duration) < 0.1
+
 class Transcription:
 
     def __init__(self, transcript=None, words=None):

--- a/gentle/transcription.py
+++ b/gentle/transcription.py
@@ -1,72 +1,42 @@
 import csv
 import io
 import json
-import math
-import logging
-import wave
 
 from collections import defaultdict
 
-from multiprocessing.pool import ThreadPool as Pool
+class Word:
 
-class MultiThreadedTranscriber:
-    def __init__(self, kaldi_queue, chunk_len=20, overlap_t=2, nthreads=4):
-        self.chunk_len = chunk_len
-        self.overlap_t = overlap_t
-        self.nthreads = nthreads
-            
-        self.kaldi_queue = kaldi_queue
+    def __init__(self, case=None, startOffset=None, endOffset=None, word=None, alignedWord=None, phones=None, start=None, end=None, duration=None):
+        self.case = case
+        self.startOffset = startOffset
+        self.endOffset = endOffset
+        self.word = word
+        self.alignedWord = alignedWord
+        self.phones = phones
+        self.start = start
+        self.end = end
+        self.duration = duration
 
-    def transcribe(self, wavfile, progress_cb=None):
-        wav_obj = wave.open(wavfile, 'r')
-        duration = wav_obj.getnframes() / float(wav_obj.getframerate())
-        n_chunks = int(math.ceil(duration / float(self.chunk_len - self.overlap_t)))
+    def as_dict(self):
+        return { key:val for key, val in self.__dict__.iteritems() if val is not None }
 
-        chunks = []
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__
 
-        def transcribe_chunk(idx):
-            wav_obj = wave.open(wavfile, 'r')
-            start_t = idx * (self.chunk_len - self.overlap_t)
-            # Seek
-            wav_obj.setpos(int(start_t * wav_obj.getframerate()))
-            # Read frames
-            buf = wav_obj.readframes(int(self.chunk_len * wav_obj.getframerate()))
+    def __ne__(self, other):
+        return not self == other
 
-            k = self.kaldi_queue.get()
-            k.push_chunk(buf)
-            ret = k.get_final()
-            k.reset()
-            self.kaldi_queue.put(k)
-
-            chunks.append({"start": start_t, "words": ret})
-            logging.info('%d/%d' % (len(chunks), n_chunks))
-            if progress_cb is not None:
-                progress_cb({"message": ' '.join([X['word'] for X in ret]),
-                             "percent": len(chunks) / float(n_chunks)})
-
-
-        pool = Pool(min(n_chunks, self.nthreads))
-        pool.map(transcribe_chunk, range(n_chunks))
-        pool.close()
-        
-        chunks.sort(key=lambda x: x['start'])
-
-        # Combine chunks
-        # TODO: remove overlap? ...or just let the sequence aligner deal with it.
-        words = []
-        for c in chunks:
-            chunk_start = c['start']
-            for wd in c['words']:
-                wd['start'] += chunk_start
-                words.append(wd)
-
-        return words
+    def __repr__(self):
+        return "Word(" + " ".join(sorted([key + "=" + str(val) for key, val in self.as_dict().iteritems()])) + ")"
 
 class Transcription:
 
     def __init__(self, transcript=None, words=None):
         self.transcript = transcript
         self.words = words
+
+    def __eq__(self, other):
+        return self.transcript == other.transcript and self.words == other.words
 
     def to_json(self, **kwargs):
         '''Return a JSON representation of the aligned transcript'''
@@ -81,7 +51,7 @@ class Transcription:
         if self.transcript:
             container['transcript'] = self.transcript
         if self.words: 
-            container['words'] = self.words
+            container['words'] = [word.as_dict() for word in self.words]
         return json.dumps(container, **options)
 
     @classmethod
@@ -106,12 +76,12 @@ class Transcription:
         buf = io.BytesIO()
         w = csv.writer(buf)
         for X in self.words:
-            if X.get("case") not in ("success", "not-found-in-audio"):
+            if X.case not in ("success", "not-found-in-audio"):
                 continue
-            row = [X["word"],
-                X.get("alignedWord"),
-                X.get("start"),
-                X.get("end")
+            row = [X.word,
+                X.alignedWord,
+                X.start,
+                X.end
             ]
             w.writerow(row)
         return buf.getvalue()
@@ -119,32 +89,11 @@ class Transcription:
     def stats(self):
         counts = defaultdict(int)
         for word in self.words:
-            counts[word["case"]] += 1
+            counts[word.case] += 1
         stats = {}
         stats['total'] = len(self.words)
         for key, val in counts.iteritems():
             stats[key] = val
         return stats
 
-
-if __name__=='__main__':
-    # full transcription
-    from Queue import Queue
-    from util import ffmpeg
-    from gentle import standard_kaldi
-
-    import sys
-
-    import logging
-    logging.getLogger().setLevel('INFO')
-    
-    k_queue = Queue()
-    for i in range(3):
-        k_queue.put(standard_kaldi.Kaldi())
-
-    trans = MultiThreadedTranscriber(k_queue)
-
-    with gentle.resampled(sys.argv[1]) as filename:
-        out = trans.transcribe(filename)
-
-    open(sys.argv[2], 'w').write(out.to_json())
+Transcription.Word = Word

--- a/www/view_alignment.html
+++ b/www/view_alignment.html
@@ -258,7 +258,7 @@ function render(ret) {
     var currentOffset = 0;
 
     wds.forEach(function(wd) {
-        if(wd['case'] == 'not-found-in-transcript') {
+        if(wd.case == 'not-found-in-transcript') {
             // TODO: show phonemes somewhere
             var txt = ' ' + wd.word;
             var $plaintext = document.createTextNode(txt);


### PR DESCRIPTION
Previously the code just concatenated the word lists of all the chunks, resulting in duplicated sections.  E.g.  The audio containing *... The quick brown fox jumps over the lazy dog ...* could be split into two overlapping chunks, that transcribe to:

1. *...The quick brown fox jumps over*
2.  *fox jumps over the lazy dog ...*

Concatenating those word lists gives *... The quick brown fox jumps over fox jumps over the lazy dog ...*

The current implementation leaves it to the sequence aligner to sort out the overlap.  But as per #107 that could lead to incorrect results in some circumstances.

To remove the overlap, this PR does the following:

1. Sort the concatenated list of words by their `start` time.   That will put overlapped words adjacent to each other, e.g.:  *...The quick brown fox fox jumps jumps over over the lazy dog ...*

2. Remove any duplicate words entries.  That is, filter out any word adjacent that's adjacent to the same word and that starts at the same time (within some error tolerance that's a fraction of the word duration).

Note, this PR is built on top of the continued refactor in PR #105, taking advantage of having a first-class `transcription.Word` object.  But if you choose not to incorporate #105, it'd be easy enough to recode this PR appropriately.  It's only a couple of lines of code :)






