### PR TITLE
Resource locations environment variable

### DIFF
--- a/gentle/resources.py
+++ b/gentle/resources.py
@@ -1,6 +1,7 @@
+import logging
 import os
 
-from util.paths import get_resource
+from util.paths import get_resource, ENV_VAR
 from gentle import metasentence
 
 class Resources():
@@ -9,5 +10,16 @@ class Resources():
         self.proto_langdir = get_resource('PROTO_LANGDIR')
         self.nnet_gpu_path = get_resource('data/nnet_a_gpu_online')
         self.full_hclg_path = get_resource('data/graph/HCLG.fst')
+
+        def require_dir(path):
+            if not os.path.isdir(path):
+                raise RuntimeError("No resource directory %s.  Check %s environment variable?" % (path, ENV_VAR))
+
+
+        require_dir(self.proto_langdir)
+        require_dir(self.nnet_gpu_path)
+
         with open(os.path.join(self.proto_langdir, "graphdir/words.txt")) as fh:
             self.vocab = metasentence.load_vocabulary(fh)
+
+

--- a/util/paths.py
+++ b/util/paths.py
@@ -4,29 +4,50 @@ import logging
 import shutil
 import sys
 
-def get_binary(name):
-    binpath = name
-    if hasattr(sys, "frozen"):
-        binpath = os.path.abspath(os.path.join(sys._MEIPASS, '..', 'Resources', name))
-    elif os.path.exists(name):
-        binpath = "./%s" % (name)
+ENV_VAR = 'GENTLE_RESOURCES_ROOT'
 
-    logging.debug("binpath %s", binpath)
-    return binpath
+class SourceResolver:
+    def __init__(self):
+        self.project_root = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir))
+
+    def get_binary(self, name):
+        path_in_project = os.path.join(self.project_root, name)
+        if os.path.exists(path_in_project):
+            return path_in_project
+        else:
+            return name
+
+    def get_resource(self, name):
+        root = os.environ.get(ENV_VAR) or self.project_root
+        return os.path.join(root, name)
+
+    def get_datadir(self, name):
+        return self.get_resource(name)
+
+class PyinstallResolver:
+    def __init__(self):
+        self.root = os.path.abspath(os.path.join(getattr(sys, '_MEIPASS', ''), os.pardir, 'Resources'))
+
+    def get_binary(self, name):
+        return os.path.join(self.root, name)
+
+    def get_resource(self, name):
+        rpath = os.path.join(self.root, path)
+        if os.path.exists(rpath):
+            return rpath
+        else:
+            return get_datadir(path) # DMG may be read-only; fall-back to datadir (ie. so language models can be added)
+
+    def get_datadir(self, path):
+        return os.path.join(os.environ['HOME'], '.gentle')
+
+RESOLVER = PyinstallResolver() if hasattr(sys, "frozen") else SourceResolver()
+
+def get_binary(name):
+    return RESOLVER.get_binary(name)
 
 def get_resource(path):
-    rpath = path
-    if hasattr(sys, "frozen"):
-        rpath = os.path.abspath(os.path.join(sys._MEIPASS, '..', 'Resources', path))
-        if not os.path.exists(rpath):
-            # DMG may be read-only; fall-back to datadir (ie. so language models can be added)
-            rpath = get_datadir(path)
-    logging.debug("resourcepath %s", rpath)
-    return rpath
+    return RESOLVER.get_resource(path)
 
 def get_datadir(path):
-    datadir = path
-    if hasattr(sys, "frozen"):# and sys.frozen == "macosx_app":
-        datadir = os.path.join(os.environ['HOME'], '.gentle', path)
-    logging.debug("datadir %s", datadir)
-    return datadir
+    return RESOLVER.get_datadir(path)


### PR DESCRIPTION
This PR provides a simple solution for the location of resource files:  The environment variable `$GENTLE_RESOURCES_ROOT` specifies the root directory that contains `PROTO_LANGDIR/**` and `data/**`.   If that variable isn't defined, the fallback is to look in the project directory (i.e. the parent directory of the source files).

This allows scripts that use Gentle to be run from other directories, and allows choosing between multiple language models that might be installed at once.

Notes:
- The executables (`ext/mkgraph` and `ext/standard_kaldi`) are always looked for relative to the project directory.  Though maybe they to should be settable?
- In the case of pyinstaller, the environment variable isn't used and the code should do what it did before.  But caveat: I haven't actually tried building with pyinstaller so I might have introduced a bug.
