### PR TITLE
More overlap improvement: discard words close to cuts at the ends of chunks

### DIFF
--- a/gentle/diff_align.py
+++ b/gentle/diff_align.py
@@ -38,14 +38,12 @@ def align(alignment, ms, **kwargs):
             if disfluency and word in disfluencies:
                 hyp_token = alignment[a]
                 phones = hyp_token.phones or []
-                start = hyp_token.start
-                end = hyp_token.start + hyp_token.duration
 
                 out.append(transcription.Word(
                     case="not-found-in-transcript",
                     phones=phones,
-                    start=start,
-                    end=end,
+                    start=hyp_token.start,
+                    duration=hyp_token.duration,
                     word=word))
             continue
 
@@ -56,8 +54,6 @@ def align(alignment, ms, **kwargs):
             hyp_word = hypothesis[a]
             hyp_token = alignment[a]
             phones = hyp_token.phones or []
-            start = hyp_token.start
-            end = hyp_token.start + hyp_token.duration
 
             out.append(transcription.Word(
                 case="success",
@@ -66,8 +62,8 @@ def align(alignment, ms, **kwargs):
                 word=display_word,
                 alignedWord=hyp_word,
                 phones=phones,
-                start=start,
-                end=end))
+                start=hyp_token.start,
+                duration=hyp_token.duration))
 
         elif op in ['insert', 'replace']:
             out.append(transcription.Word(

--- a/gentle/full_transcriber.py
+++ b/gentle/full_transcriber.py
@@ -34,7 +34,7 @@ class FullTranscriber():
                 alignedWord=t_wd.word,
                 phones=t_wd.phones,
                 start=t_wd.start,
-                end=t_wd.start + t_wd.duration)
+                end=t_wd.end)
             words.append(word)
 
             transcript += word.word + " "

--- a/gentle/multipass.py
+++ b/gentle/multipass.py
@@ -80,16 +80,8 @@ def realign(wavfile, alignment, ms, resources, nthreads=4, progress_cb=None):
 
         word_alignment = diff_align.align(ret, chunk_ms)
 
-        # Adjust startOffset, endOffset, and timing to match originals
         for wd in word_alignment:
-            if wd.end is not None:
-                # Apply timing offset
-                wd.start += start_t
-                wd.end += start_t
-
-            if wd.endOffset is not None:
-                wd.startOffset += offset_offset
-                wd.endOffset += offset_offset
+            wd.shift(time=start_t, offset=offset_offset)
 
         # "chunk" should be replaced by "words"
         realignments.append({"chunk": chunk, "words": word_alignment})

--- a/gentle/resources.py
+++ b/gentle/resources.py
@@ -1,6 +1,7 @@
+import logging
 import os
 
-from util.paths import get_resource
+from util.paths import get_resource, ENV_VAR
 from gentle import metasentence
 
 class Resources():
@@ -9,5 +10,16 @@ class Resources():
         self.proto_langdir = get_resource('PROTO_LANGDIR')
         self.nnet_gpu_path = get_resource('data/nnet_a_gpu_online')
         self.full_hclg_path = get_resource('data/graph/HCLG.fst')
+
+        def require_dir(path):
+            if not os.path.isdir(path):
+                raise RuntimeError("No resource directory %s.  Check %s environment variable?" % (path, ENV_VAR))
+
+
+        require_dir(self.proto_langdir)
+        require_dir(self.nnet_gpu_path)
+
         with open(os.path.join(self.proto_langdir, "graphdir/words.txt")) as fh:
             self.vocab = metasentence.load_vocabulary(fh)
+
+

--- a/gentle/transcriber.py
+++ b/gentle/transcriber.py
@@ -49,12 +49,7 @@ class MultiThreadedTranscriber:
         chunks.sort(key=lambda x: x['start'])
 
         # Combine chunks
-        words = []
-        for c in chunks:
-            chunk_start = c['start']
-            for wd in c['words']:
-                wd['start'] += chunk_start
-                words.append(transcription.Word(**wd))
+        words = [transcription.Word(**wd).shift(time=c['start']) for c in chunks for wd in c['words']]
 
         # Remove overlap:  Sort by time, then filter out any Word entries in
         # the list that are adjacent to another entry corresponding to the same

--- a/gentle/transcriber.py
+++ b/gentle/transcriber.py
@@ -49,7 +49,31 @@ class MultiThreadedTranscriber:
         chunks.sort(key=lambda x: x['start'])
 
         # Combine chunks
-        words = [transcription.Word(**wd).shift(time=c['start']) for c in chunks for wd in c['words']]
+        words = []
+        for c in chunks:
+            chunk_start = c['start']
+            chunk_end = chunk_start + self.chunk_len
+
+            chunk_words = [transcription.Word(**wd).shift(time=chunk_start) for wd in c['words']]
+
+            # At chunk boundary cut points the audio often contains part of a
+            # word, which can get erroneously identified as one or more different
+            # in-vocabulary words.  So discard one or more words near the cut points
+            # (they'll be covered by the ovlerap anyway).
+            #
+            trim = min(0.25 * self.overlap_t, 0.5)
+            if c is not chunks[0]:
+                while len(chunk_words) > 1:
+                    chunk_words.pop(0)
+                    if chunk_words[0].end > chunk_start + trim:
+                        break
+            if c is not chunks[-1]:
+                while len(chunk_words) > 1:
+                    chunk_words.pop()
+                    if chunk_words[-1].start < chunk_end - trim:
+                        break
+
+            words.extend(chunk_words)
 
         # Remove overlap:  Sort by time, then filter out any Word entries in
         # the list that are adjacent to another entry corresponding to the same

--- a/gentle/transcription.py
+++ b/gentle/transcription.py
@@ -14,11 +14,17 @@ class Word:
         self.alignedWord = alignedWord
         self.phones = phones
         self.start = start
-        self.end = end
         self.duration = duration
+        self.end = end
+        if start is not None:
+            if end is None:
+                self.end = start + duration
+            elif duration is None:
+                self.duration = end - start
 
-    def as_dict(self):
-        return { key:val for key, val in self.__dict__.iteritems() if val is not None }
+
+    def as_dict(self, without=None):
+        return { key:val for key, val in self.__dict__.iteritems() if (val is not None) and (key != without)}
 
     def __eq__(self, other):
         return self.__dict__ == other.__dict__
@@ -27,7 +33,18 @@ class Word:
         return not self == other
 
     def __repr__(self):
-        return "Word(" + " ".join(sorted([key + "=" + str(val) for key, val in self.as_dict().iteritems()])) + ")"
+        return "Word(" + " ".join(sorted([key + "=" + str(val) for key, val in self.as_dict(without="phones").iteritems()])) + ")"
+
+    def shift(self, time=None, offset=None):
+        if self.start is not None and time is not None:
+            self.start += time
+            self.end += time
+
+        if self.startOffset is not None and offset is not None:
+            self.startOffset += offset
+            self.endOffset += offset
+
+        return self # for easy chaining
 
     def corresponds(self, other):
         '''Returns true if self and other refer to the same word, at the same position in the audio (within a small tolerance)'''
@@ -56,7 +73,7 @@ class Transcription:
         if self.transcript:
             container['transcript'] = self.transcript
         if self.words: 
-            container['words'] = [word.as_dict() for word in self.words]
+            container['words'] = [word.as_dict(without="duration") for word in self.words]
         return json.dumps(container, **options)
 
     @classmethod

--- a/util/paths.py
+++ b/util/paths.py
@@ -4,29 +4,50 @@ import logging
 import shutil
 import sys
 
-def get_binary(name):
-    binpath = name
-    if hasattr(sys, "frozen"):
-        binpath = os.path.abspath(os.path.join(sys._MEIPASS, '..', 'Resources', name))
-    elif os.path.exists(name):
-        binpath = "./%s" % (name)
+ENV_VAR = 'GENTLE_RESOURCES_ROOT'
 
-    logging.debug("binpath %s", binpath)
-    return binpath
+class SourceResolver:
+    def __init__(self):
+        self.project_root = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir))
+
+    def get_binary(self, name):
+        path_in_project = os.path.join(self.project_root, name)
+        if os.path.exists(path_in_project):
+            return path_in_project
+        else:
+            return name
+
+    def get_resource(self, name):
+        root = os.environ.get(ENV_VAR) or self.project_root
+        return os.path.join(root, name)
+
+    def get_datadir(self, name):
+        return self.get_resource(name)
+
+class PyinstallResolver:
+    def __init__(self):
+        self.root = os.path.abspath(os.path.join(getattr(sys, '_MEIPASS', ''), os.pardir, 'Resources'))
+
+    def get_binary(self, name):
+        return os.path.join(self.root, name)
+
+    def get_resource(self, name):
+        rpath = os.path.join(self.root, path)
+        if os.path.exists(rpath):
+            return rpath
+        else:
+            return get_datadir(path) # DMG may be read-only; fall-back to datadir (ie. so language models can be added)
+
+    def get_datadir(self, path):
+        return os.path.join(os.environ['HOME'], '.gentle')
+
+RESOLVER = PyinstallResolver() if hasattr(sys, "frozen") else SourceResolver()
+
+def get_binary(name):
+    return RESOLVER.get_binary(name)
 
 def get_resource(path):
-    rpath = path
-    if hasattr(sys, "frozen"):
-        rpath = os.path.abspath(os.path.join(sys._MEIPASS, '..', 'Resources', path))
-        if not os.path.exists(rpath):
-            # DMG may be read-only; fall-back to datadir (ie. so language models can be added)
-            rpath = get_datadir(path)
-    logging.debug("resourcepath %s", rpath)
-    return rpath
+    return RESOLVER.get_resource(path)
 
 def get_datadir(path):
-    datadir = path
-    if hasattr(sys, "frozen"):# and sys.frozen == "macosx_app":
-        datadir = os.path.join(os.environ['HOME'], '.gentle', path)
-    logging.debug("datadir %s", datadir)
-    return datadir
+    return RESOLVER.get_datadir(path)


### PR DESCRIPTION
Based on the previous experience where the `diff_align` can accidentally go bad if given tricky input, this PR aims to clean up the input to the alignment a bit more.

When splitting the audio into chunks, often the cut point ends up breaking a word in two.  That means that the end of a chunk or the start of a chunk is trying to match part of a word.  E.g. a chunk might start in the middle of the word _connection_, so that the chunk's first phoneme is _-tion..._, which might happen to match the word `shun` if it's somewhere the transcript, or `on` pretty likely.  Sometimes a few mismatched words might turn up.

Because of that, I think the first/last word or few words that kaldi finds in a chunk are likely to be erroneous.  So this PR simply discards the first/last words up to a small "trim" duration (I chose 0.5 seconds based on inspection of some cases).  Note that because of the overlap, the full word is in the adjacent chunk so can be matched by kaldi, so trimming not likely to harm the final result.

What do you think?
