### PR TITLE
Minor code cleanup:  methods and constants instead of raw strings

### DIFF
--- a/gentle/diff_align.py
+++ b/gentle/diff_align.py
@@ -40,7 +40,7 @@ def align(alignment, ms, **kwargs):
                 phones = hyp_token.phones or []
 
                 out.append(transcription.Word(
-                    case="not-found-in-transcript",
+                    case=transcription.Word.NOT_FOUND_IN_TRANSCRIPT,
                     phones=phones,
                     start=hyp_token.start,
                     duration=hyp_token.duration,
@@ -56,7 +56,7 @@ def align(alignment, ms, **kwargs):
             phones = hyp_token.phones or []
 
             out.append(transcription.Word(
-                case="success",
+                case=transcription.Word.SUCCESS,
                 startOffset=start_offset,
                 endOffset=end_offset,
                 word=display_word,
@@ -67,7 +67,7 @@ def align(alignment, ms, **kwargs):
 
         elif op in ['insert', 'replace']:
             out.append(transcription.Word(
-                case="not-found-in-audio",
+                case=transcription.Word.NOT_FOUND_IN_AUDIO,
                 startOffset=start_offset,
                 endOffset=end_offset,
                 word=display_word))

--- a/gentle/forced_aligner.py
+++ b/gentle/forced_aligner.py
@@ -32,7 +32,7 @@ class ForcedAligner():
 
         # Perform a second-pass with unaligned words
         if logging is not None:
-            logging.info("%d unaligned words (of %d)" % (len([X for X in words if X.case == "not-found-in-audio"]), len(words)))
+            logging.info("%d unaligned words (of %d)" % (len([X for X in words if X.not_found_in_audio()]), len(words)))
 
         if progress_cb is not None:
             progress_cb({'status': 'ALIGNING'})
@@ -40,6 +40,6 @@ class ForcedAligner():
         words = multipass.realign(wavfile, words, self.ms, resources=self.resources, nthreads=self.nthreads, progress_cb=progress_cb)
 
         if logging is not None:
-            logging.info("after 2nd pass: %d unaligned words (of %d)" % (len([X for X in words if X.case == "not-found-in-audio"]), len(words)))
+            logging.info("after 2nd pass: %d unaligned words (of %d)" % (len([X for X in words if X.not_found_in_audio()]), len(words)))
 
         return Transcription(words=words, transcript=self.transcript)

--- a/gentle/full_transcriber.py
+++ b/gentle/full_transcriber.py
@@ -27,7 +27,7 @@ class FullTranscriber():
         words = []
         for t_wd in trans:
             word = transcription.Word(
-                case="success",
+                case=transcription.Word.SUCCESS,
                 startOffset=len(transcript),
                 endOffset=len(transcript) + len(t_wd.word),
                 word=t_wd.word,

--- a/gentle/multipass.py
+++ b/gentle/multipass.py
@@ -15,9 +15,9 @@ def prepare_multipass(alignment):
     cur_unaligned_words = []
 
     for wd_idx,wd in enumerate(alignment):
-        if wd.case == 'not-found-in-audio':
+        if wd.not_found_in_audio():
             cur_unaligned_words.append(wd)
-        elif wd.case == 'success':
+        elif wd.success():
             if len(cur_unaligned_words) > 0:
                 to_realign.append({
                     "start": last_aligned_word,

--- a/gentle/transcription.py
+++ b/gentle/transcription.py
@@ -6,6 +6,10 @@ from collections import defaultdict
 
 class Word:
 
+    SUCCESS = 'success'
+    NOT_FOUND_IN_AUDIO = 'not-found-in-audio'
+    NOT_FOUND_IN_TRANSCRIPT = 'not-found-in-transcript'
+
     def __init__(self, case=None, startOffset=None, endOffset=None, word=None, alignedWord=None, phones=None, start=None, end=None, duration=None):
         self.case = case
         self.startOffset = startOffset
@@ -22,6 +26,11 @@ class Word:
             elif duration is None:
                 self.duration = end - start
 
+    def success(self):
+        return self.case == Word.SUCCESS
+
+    def not_found_in_audio(self):
+        return self.case == Word.NOT_FOUND_IN_AUDIO
 
     def as_dict(self, without=None):
         return { key:val for key, val in self.__dict__.iteritems() if (val is not None) and (key != without)}
@@ -98,7 +107,7 @@ class Transcription:
         buf = io.BytesIO()
         w = csv.writer(buf)
         for X in self.words:
-            if X.case not in ("success", "not-found-in-audio"):
+            if X.case not in (Word.SUCCESS, Word.NOT_FOUND_IN_AUDIO):
                 continue
             row = [X.word,
                 X.alignedWord,


### PR DESCRIPTION
Rather than assigning and testing raw strings, define constants: 

```python
Word.SUCCESS = 'success'
Word.NOT_FOUND_IN_AUDIO = 'not-found-in-audio'
Word.NOT_FOUND_IN_TRANSCRIPT = 'not-found-in-transcript'
```

and methods:

```python
word.success()
word.not_found_in_audio()
```

This to avoid potential mystery bugs by typos such as `if word.case == 'succes'` which would silently give the wrong behavior. With this PR any such typo will yield an `AttributeError`