### PR TITLE
Adjaceny optimization: Improve behavior when diff alignment is ambiguous

### DIFF
--- a/gentle/diff_align.py
+++ b/gentle/diff_align.py
@@ -40,7 +40,7 @@ def align(alignment, ms, **kwargs):
                 phones = hyp_token.phones or []
 
                 out.append(transcription.Word(
-                    case="not-found-in-transcript",
+                    case=transcription.Word.NOT_FOUND_IN_TRANSCRIPT,
                     phones=phones,
                     start=hyp_token.start,
                     duration=hyp_token.duration,
@@ -56,7 +56,7 @@ def align(alignment, ms, **kwargs):
             phones = hyp_token.phones or []
 
             out.append(transcription.Word(
-                case="success",
+                case=transcription.Word.SUCCESS,
                 startOffset=start_offset,
                 endOffset=end_offset,
                 word=display_word,
@@ -67,7 +67,7 @@ def align(alignment, ms, **kwargs):
 
         elif op in ['insert', 'replace']:
             out.append(transcription.Word(
-                case="not-found-in-audio",
+                case=transcription.Word.NOT_FOUND_IN_AUDIO,
                 startOffset=start_offset,
                 endOffset=end_offset,
                 word=display_word))

--- a/gentle/forced_aligner.py
+++ b/gentle/forced_aligner.py
@@ -20,7 +20,7 @@ class ForcedAligner():
         self.mtt = MultiThreadedTranscriber(self.queue, nthreads=nthreads)
 
     def transcribe(self, wavfile, progress_cb=None, logging=None):
-        words = self.mtt.transcribe(wavfile, progress_cb=progress_cb)
+        words, duration = self.mtt.transcribe(wavfile, progress_cb=progress_cb)
 
         # Clear queue (would this be gc'ed?)
         for i in range(self.nthreads):
@@ -42,4 +42,130 @@ class ForcedAligner():
         if logging is not None:
             logging.info("after 2nd pass: %d unaligned words (of %d)" % (len([X for X in words if X.not_found_in_audio()]), len(words)))
 
+        words = AdjacencyOptimizer(words, duration).optimize()
+
         return Transcription(words=words, transcript=self.transcript)
+
+
+class AdjacencyOptimizer():
+
+    '''
+    Sometimes there are ambiguous possible placements of not-found-in-audio
+    words.  The word-based diff doesn't take into account intra-word timings
+    when it does insertion, so can create strange results.  E.g. if the audio
+    contains these words with timings like
+
+        "She climbed on the bed and jumped on the mattress"
+            0     1    2   3   4    5   6    7   8     9
+
+    and suppose the speaker mumbled or there was noise obscuring the words
+    "on the bed and jumped", so the hypothesis is just "She climbed on the mattress".
+
+    The intended alignment would be to insert the missing out-of-audio words:
+
+        "She climbed [on the bed and jumped] on the mattress"
+            0     1                            7   8     9
+
+    But the word-based diff might instead align "on the" with the first
+    occurrence, and so insert out-of-audio words like this:
+
+        "She climbed on the [bed and jumped on the] mattress"
+            0     1    7   8                             9
+
+    with a big gap in between "climbed" and "on" and no time available for
+    "[bend and jumped on the]".
+
+    Or imagine a case such as "I really really really really want to do
+    this", where only one of the "really"s is in the hypothesis, so again
+    the choice word-based choice of which to align it with is arbitrary.
+
+    This method cleans those up, by checking each not-found-in-audio sequence
+    of words to see if its neighbor(s) are candidates for moving inward and
+    whether doing so would improve adjacent intra-word distances.
+    '''
+
+    def __init__(self, words, duration):
+        self.words = words
+        self.duration = duration
+
+    def out_of_audio_sequence(self, i):
+        j = i
+        while 0 <= j < len(self.words) and self.words[j].not_found_in_audio():
+            j += 1
+        return None if j == i else j
+
+    def tend(self, i):
+        for word in reversed(self.words[:i]):
+            if word.success():
+                return word.end
+        return 0
+
+    def tstart(self, i):
+        for word in self.words[i:]:
+            if word.success():
+                return word.start
+        return self.duration
+
+    def find_subseq(self, i, j, p, n):
+        for k in range(i, j-n+1):
+            for m in range(p, p+n):
+                if self.words[k].word != self.words[m].word:
+                    break
+            else:
+                return k
+        return None
+
+    def swap_adjacent_if_better(self, i, j, n, side):
+        '''Given an out-of-audio sequence at [i,j), looks to see if the adjacent n words
+        can be beneficially swapped with a subsequence.'''
+
+        # construct adjacent candidate words and their gap relative to their
+        # opposite neighbors
+        if side == "left":
+            p, q = (i-n, i)
+            if p < 0: return False
+            opp_gap = self.tstart(p) - self.tend(p)
+        else:
+            p, q = (j, j+n)
+            if q > len(self.words): return False
+            opp_gap = self.tstart(q) - self.tend(q)
+
+        # is there a matching subsequence?
+        k = self.find_subseq(i, j, p, n)
+        if k is None: return False
+
+        # if the opposite gap isn't bigger than the sequence gap, no benefit to
+        # potential swap
+        seq_gap = self.tstart(j) - self.tend(i)
+        if opp_gap <= seq_gap: return False
+
+        # swap subsequences at p and k
+        for m in range(0, n):
+            self.words[k+m].swap_alignment(self.words[p+m])
+
+        return True
+
+    def optimize_adjacent(self, i, j):
+        '''Given an out-of-audio sequence at [i,j), looks for an opportunity to
+        swap a sub-sequence with adjacent words at [p, i) or [j, p)'''
+
+        for n in reversed(range(1, (j-i)+1)): # consider larger moves first
+            if self.swap_adjacent_if_better(i, j, n, "left"): return True
+            if self.swap_adjacent_if_better(i, j, n, "right"): return True
+
+    def optimize(self):
+        i = 0
+        while i < len(self.words):
+            j = self.out_of_audio_sequence(i)
+            if j is None:
+                i += 1
+
+            elif self.optimize_adjacent(i, j):
+                # back up to rescan in case we swapped left
+                while i >= 0 and self.words[i].not_found_in_audio():
+                    i -= 1
+
+            else:
+                i = j # skip past this sequence
+
+        return self.words

--- a/gentle/forced_aligner.py
+++ b/gentle/forced_aligner.py
@@ -32,7 +32,7 @@ class ForcedAligner():
 
         # Perform a second-pass with unaligned words
         if logging is not None:
-            logging.info("%d unaligned words (of %d)" % (len([X for X in words if X.case == "not-found-in-audio"]), len(words)))
+            logging.info("%d unaligned words (of %d)" % (len([X for X in words if X.not_found_in_audio()]), len(words)))
 
         if progress_cb is not None:
             progress_cb({'status': 'ALIGNING'})
@@ -40,6 +40,6 @@ class ForcedAligner():
         words = multipass.realign(wavfile, words, self.ms, resources=self.resources, nthreads=self.nthreads, progress_cb=progress_cb)
 
         if logging is not None:
-            logging.info("after 2nd pass: %d unaligned words (of %d)" % (len([X for X in words if X.case == "not-found-in-audio"]), len(words)))
+            logging.info("after 2nd pass: %d unaligned words (of %d)" % (len([X for X in words if X.not_found_in_audio()]), len(words)))
 
         return Transcription(words=words, transcript=self.transcript)

--- a/gentle/full_transcriber.py
+++ b/gentle/full_transcriber.py
@@ -27,7 +27,7 @@ class FullTranscriber():
         words = []
         for t_wd in trans:
             word = transcription.Word(
-                case="success",
+                case=transcription.Word.SUCCESS,
                 startOffset=len(transcript),
                 endOffset=len(transcript) + len(t_wd.word),
                 word=t_wd.word,

--- a/gentle/full_transcriber.py
+++ b/gentle/full_transcriber.py
@@ -17,7 +17,7 @@ class FullTranscriber():
         self.available = True
 
     def transcribe(self, wavfile, progress_cb=None, logging=None):
-        words = self.mtt.transcribe(wavfile, progress_cb=progress_cb)
+        words, duration = self.mtt.transcribe(wavfile, progress_cb=progress_cb)
         return self.make_transcription_alignment(words)
 
     @staticmethod

--- a/gentle/multipass.py
+++ b/gentle/multipass.py
@@ -15,9 +15,9 @@ def prepare_multipass(alignment):
     cur_unaligned_words = []
 
     for wd_idx,wd in enumerate(alignment):
-        if wd.case == 'not-found-in-audio':
+        if wd.not_found_in_audio():
             cur_unaligned_words.append(wd)
-        elif wd.case == 'success':
+        elif wd.success():
             if len(cur_unaligned_words) > 0:
                 to_realign.append({
                     "start": last_aligned_word,

--- a/gentle/transcriber.py
+++ b/gentle/transcriber.py
@@ -82,7 +82,7 @@ class MultiThreadedTranscriber:
         words.append(transcription.Word(word="__dummy__"))
         words = [words[i] for i in range(len(words)-1) if not words[i].corresponds(words[i+1])]
 
-        return words
+        return words, duration
 
 
 if __name__=='__main__':

--- a/gentle/transcription.py
+++ b/gentle/transcription.py
@@ -6,6 +6,10 @@ from collections import defaultdict
 
 class Word:
 
+    SUCCESS = 'success'
+    NOT_FOUND_IN_AUDIO = 'not-found-in-audio'
+    NOT_FOUND_IN_TRANSCRIPT = 'not-found-in-transcript'
+
     def __init__(self, case=None, startOffset=None, endOffset=None, word=None, alignedWord=None, phones=None, start=None, end=None, duration=None):
         self.case = case
         self.startOffset = startOffset
@@ -22,6 +26,11 @@ class Word:
             elif duration is None:
                 self.duration = end - start
 
+    def success(self):
+        return self.case == Word.SUCCESS
+
+    def not_found_in_audio(self):
+        return self.case == Word.NOT_FOUND_IN_AUDIO
 
     def as_dict(self, without=None):
         return { key:val for key, val in self.__dict__.iteritems() if (val is not None) and (key != without)}
@@ -98,7 +107,7 @@ class Transcription:
         buf = io.BytesIO()
         w = csv.writer(buf)
         for X in self.words:
-            if X.case not in ("success", "not-found-in-audio"):
+            if X.case not in (Word.SUCCESS, Word.NOT_FOUND_IN_AUDIO):
                 continue
             row = [X.word,
                 X.alignedWord,

--- a/gentle/transcription.py
+++ b/gentle/transcription.py
@@ -55,6 +55,15 @@ class Word:
 
         return self # for easy chaining
 
+    def swap_alignment(self, other):
+        '''Swaps the alignment info of two words, but does not swap the offset'''
+        self.case, other.case = other.case, self.case
+        self.alignedWord, other.alignedWord = other.alignedWord, self.alignedWord
+        self.phones, other.phones = other.phones, self.phones
+        self.start, other.start = other.start, self.start
+        self.end, other.end = other.end, self.end
+        self.duration, other.duration = other.duration, self.duration
+
     def corresponds(self, other):
         '''Returns true if self and other refer to the same word, at the same position in the audio (within a small tolerance)'''
         if self.word != other.word: return False


### PR DESCRIPTION
Not just hypothetical... I came across a case like this in practice!

Sometimes there are ambiguous possible placements of not-found-in-audio words.  The word-based diff doesn't take into account intra-word timings when it does insertion, so can create strange results.  

Consider this example.  Transcript and audio contain these words with timings:

```
She climbed on the bed and jumped on the mattress
 0     1    2   3   4    5   6    7   8     9
```
and suppose the speaker mumbled or there was noise obscuring the words *on the bed and jumped*, so the hypothesis is just 

```
She climbed on the mattress
 0     1    7   8     9
```

The proper alignment would be to insert the missing not-found-in-audio words *on the bed and jumped*:

```
She climbed [on the bed and jumped] on the mattress
  0     1                           7   8     9
```

But the word-based diff might instead align *on the* in the audio with the first occurrence in the transcript, inserting *bed and jumped on the* as the not-found-in-audio words:

```
She climbed on the [bed and jumped on the] mattress
  0     1    7   8                             9
```

The result is that there's a big gap in timing between *climbed* and *on*, and no time available for *bed and jumped on the*.  I.e. a pretty unacceptable alignment.

This PR contains code to clean that up by checking each not-found-in-audio sequence of words to see if its neighbor(s) are candidates for moving inward and  whether doing so would improve adjacent intra-word distances.

It seems to work fine.  The downside is that it's a lot of code to handle an infrequent case.  I didn't manage to come up with any more clever/less code solution.  Maybe you can?
