### PR TITLE
support custom models

### DIFF
--- a/ext/k3.cc
+++ b/ext/k3.cc
@@ -62,8 +62,8 @@ void ConfigDecoding(kaldi::OnlineNnet3DecodingConfig& config) {
   config.decoder_opts.max_active = 7000;
 }
 
-void ConfigEndpoint(kaldi::OnlineEndpointConfig& config) {
-  config.silence_phones = "1:2:3:4:5:6:7:8:9:10:11:12:13:14:15:16:17:18:19:20";
+void ConfigEndpoint(kaldi::OnlineEndpointConfig& config, const std::string &silence_phones) {
+  config.silence_phones = silence_phones;
 }
 void usage() {
   fprintf(stderr, "usage: k3 [nnet_dir hclg_path]\n");
@@ -78,10 +78,17 @@ int main(int argc, char *argv[]) {
     std::string nnet_dir = "exp/tdnn_7b_chain_online";
     std::string graph_dir = nnet_dir + "/graph_pp";
     std::string fst_rxfilename = graph_dir + "/HCLG.fst";
+    std::string silence_phones = "1:2:3:4:5:6:7:8:9:10:11:12:13:14:15:16:17:18:19:20";
     
-    if(argc == 3) {
+    if(argc == 4) {
       nnet_dir = argv[1];
-      graph_dir = nnet_dir + "/graph_pp";
+      graph_dir = nnet_dir + "/graph";
+      fst_rxfilename = argv[2];
+      silence_phones = argv[3]; 
+    }
+    else if(argc == 3) {
+      nnet_dir = argv[1];
+      graph_dir = nnet_dir + "/graph";
       fst_rxfilename = argv[2];
     }
     else if(argc != 1) {
@@ -104,7 +111,7 @@ int main(int argc, char *argv[]) {
     OnlineNnet3DecodingConfig nnet3_decoding_config;
     ConfigDecoding(nnet3_decoding_config);
     OnlineEndpointConfig endpoint_config;
-    ConfigEndpoint(endpoint_config);
+    ConfigEndpoint(endpoint_config, silence_phones);
     
 
     BaseFloat frame_shift = feature_info.FrameShiftInSeconds();

--- a/ext/m3.cc
+++ b/ext/m3.cc
@@ -15,16 +15,18 @@ int main(int argc, char *argv[]) {
 	try {
 		const char *usage = "Usage: ./mkgraph [options] <proto-dir> <grammar-fst> <out-fst>\n";
 		
+
+		int32 N = 3, P = 1;
+		float transition_scale = 1.0;
+		float self_loop_scale = 0.1;
+
 		ParseOptions po(usage);
+		po.Register("N", &N, "context width");
 		po.Read(argc, argv);
 		if (po.NumArgs() != 3) {
 			po.PrintUsage();
 			return 1;
 		}
-
-		int32 N = 3, P = 1;
-		float transition_scale = 1.0;
-		float self_loop_scale = 0.1;
 
 		std::string proto_dir = po.GetArg(1),
 					grammar_fst_filename = po.GetArg(2),
@@ -33,9 +35,9 @@ int main(int argc, char *argv[]) {
 		std::string lang_fst_filename = proto_dir + "/langdir/L.fst",
 			lang_disambig_fst_filename = proto_dir + "/langdir/L_disambig.fst",
 			disambig_phones_filename = proto_dir + "/langdir/phones/disambig.int",
-			model_filename = proto_dir + "/tdnn_7b_chain_online/final.mdl",
-			tree_filename = proto_dir + "/tdnn_7b_chain_online/tree",
-			words_filename = proto_dir + "/tdnn_7b_chain_online/graph_pp/words.txt";
+			model_filename = proto_dir + "/online/final.mdl",
+			tree_filename = proto_dir + "/online/tree",
+			words_filename = proto_dir + "/online/graph/words.txt";
 
 		if (!std::ifstream(lang_fst_filename.c_str())) {
 			std::cerr << "expected " << lang_fst_filename << " to exist" << std::endl;

--- a/gentle/forced_aligner.py
+++ b/gentle/forced_aligner.py
@@ -8,14 +8,15 @@ from gentle.transcription import Transcription
 
 class ForcedAligner():
 
-    def __init__(self, resources, transcript, nthreads=4, **kwargs):
+    def __init__(self, resources, transcript, nthreads=4, context_width=3, **kwargs):
         self.kwargs = kwargs
         self.nthreads = nthreads
         self.transcript = transcript
         self.resources = resources
+        self.context_width = context_width
         self.ms = metasentence.MetaSentence(transcript, resources.vocab)
         ks = self.ms.get_kaldi_sequence()
-        gen_hclg_filename = language_model.make_bigram_language_model(ks, resources.proto_langdir, **kwargs)
+        gen_hclg_filename = language_model.make_bigram_language_model(ks, resources.proto_langdir, context_width=context_width, **kwargs)
         self.queue = kaldi_queue.build(resources, hclg_path=gen_hclg_filename, nthreads=nthreads)
         self.mtt = MultiThreadedTranscriber(self.queue, nthreads=nthreads)
 
@@ -37,7 +38,7 @@ class ForcedAligner():
         if progress_cb is not None:
             progress_cb({'status': 'ALIGNING'})
 
-        words = multipass.realign(wavfile, words, self.ms, resources=self.resources, nthreads=self.nthreads, progress_cb=progress_cb)
+        words = multipass.realign(wavfile, words, self.ms, context_width=self.context_width, resources=self.resources, nthreads=self.nthreads, progress_cb=progress_cb)
 
         if logging is not None:
             logging.info("after 2nd pass: %d unaligned words (of %d)" % (len([X for X in words if X.not_found_in_audio()]), len(words)))

--- a/gentle/language_model.py
+++ b/gentle/language_model.py
@@ -94,7 +94,7 @@ def make_bigram_lm_fst(word_sequences, **kwargs):
 
     return output
 
-def make_bigram_language_model(kaldi_seq, proto_langdir, **kwargs):
+def make_bigram_language_model(kaldi_seq, proto_langdir, context_width=3, **kwargs):
     """Generates a language model to fit the text.
 
     Returns the filename of the generated language model FST.
@@ -114,6 +114,7 @@ def make_bigram_language_model(kaldi_seq, proto_langdir, **kwargs):
     try:
         devnull = open(os.devnull, 'wb')
         subprocess.check_output([MKGRAPH_PATH,
+                        "--N={}".format(context_width),
                         proto_langdir,
                         txt_fst_file.name,
                         hclg_filename],

--- a/gentle/multipass.py
+++ b/gentle/multipass.py
@@ -35,7 +35,7 @@ def prepare_multipass(alignment):
 
     return to_realign
     
-def realign(wavfile, alignment, ms, resources, nthreads=4, progress_cb=None):
+def realign(wavfile, alignment, ms, resources, nthreads=4, context_width='3', progress_cb=None):
     to_realign = prepare_multipass(alignment)
     realignments = []
 
@@ -65,7 +65,7 @@ def realign(wavfile, alignment, ms, resources, nthreads=4, progress_cb=None):
         chunk_ms = metasentence.MetaSentence(chunk_transcript, resources.vocab)
         chunk_ks = chunk_ms.get_kaldi_sequence()
 
-        chunk_gen_hclg_filename = language_model.make_bigram_language_model(chunk_ks, resources.proto_langdir)
+        chunk_gen_hclg_filename = language_model.make_bigram_language_model(chunk_ks, resources.proto_langdir, context_width=context_width)
         k = standard_kaldi.Kaldi(
             resources.nnet_gpu_path,
             chunk_gen_hclg_filename,

--- a/gentle/resample.py
+++ b/gentle/resample.py
@@ -9,7 +9,7 @@ from util.paths import get_binary
 
 FFMPEG = get_binary("ffmpeg")
 
-def resample(infile, outfile):
+def resample(infile, outfile, samplerate=8000):
     if not os.path.isfile(infile):
         raise IOError("Not a file: %s" % infile)
 
@@ -20,13 +20,13 @@ def resample(infile, outfile):
                             '-loglevel', 'panic',
                             '-y',
                             '-i', infile,
-                            '-ac', '1', '-ar', '8000',
+                            '-ac', '1', '-ar', '{}'.format(samplerate),
                             '-acodec', 'pcm_s16le',
                             outfile])
 
 @contextmanager
-def resampled(infile):
+def resampled(infile, samplerate=8000):
     with tempfile.NamedTemporaryFile(suffix='.wav') as fp:
-        if resample(infile, fp.name) != 0:
+        if resample(infile, fp.name, samplerate) != 0:
             raise RuntimeError("Unable to resample/encode '%s'" % infile)
         yield fp.name

--- a/gentle/resources.py
+++ b/gentle/resources.py
@@ -1,15 +1,42 @@
 import logging
 import os
+import yaml
 
 from util.paths import get_resource, ENV_VAR
 from gentle import metasentence
 
-class Resources():
+class Singleton(type):
+    _instances = {}
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+        return cls._instances[cls]
 
+class Config:
+    __metaclass__ = Singleton
     def __init__(self):
-        self.proto_langdir = get_resource('exp')
-        self.nnet_gpu_path = get_resource('exp/tdnn_7b_chain_online/')
-        self.full_hclg_path = get_resource('exp/tdnn_7b_chain_online/graph_pp/HCLG.fst')
+        self.config = {
+            'samplerate': 8000,
+            'silencephones': '1:2:3:4:5:6:7:8:9:10',
+            'context-width': '3'}
+
+    def load(self, configFileName):
+        with open(configFileName, 'r') as f:
+            self.config = yaml.safe_load(f)
+
+    def __getitem__(self, key):
+        return self.config.__getitem__(key)
+
+class Resources:
+    def __init__(self, modelDir):
+        self.proto_langdir = get_resource(modelDir)
+        self.nnet_gpu_path = get_resource(os.path.join(modelDir, 'online'))
+        self.full_hclg_path = get_resource(os.path.join(self.nnet_gpu_path, 'graph', 'HCLG.fst'))
+
+        self.config = Config()
+        confPath = os.path.join(self.proto_langdir, 'config.yaml')
+        if os.path.exists(confPath):
+            self.config.load(confPath)
 
         def require_dir(path):
             if not os.path.isdir(path):
@@ -22,4 +49,12 @@ class Resources():
         with open(os.path.join(self.proto_langdir, "langdir", "words.txt")) as fh:
             self.vocab = metasentence.load_vocabulary(fh)
 
+    def getConfig(self):
+        return self.config
+
+if __name__ == '__main__':
+    resources = Resources('exp')
+    config1 = resources.getConfig()
+    config2 = Config('')
+    print config1['samplerate'], config2['silencephones']
 

--- a/gentle/standard_kaldi.py
+++ b/gentle/standard_kaldi.py
@@ -1,6 +1,7 @@
 import subprocess
 from util.paths import get_binary
 import os
+from resources import Config
 
 EXECUTABLE_PATH = get_binary("ext/k3")
 
@@ -10,9 +11,12 @@ class Kaldi:
         
         cmd = [EXECUTABLE_PATH]
         
+        self.config = Config()
+
         if nnet_dir is not None:
             cmd.append(nnet_dir)
             cmd.append(hclg_path)
+            cmd.append(self.config['silencephones'])
 
         self._p = subprocess.Popen(cmd,
                                    stdin=subprocess.PIPE, stdout=subprocess.PIPE,

--- a/serve.py
+++ b/serve.py
@@ -27,7 +27,7 @@ class TranscriptionStatus(Resource):
         return json.dumps(self.status_dict)
 
 class Transcriber():
-    def __init__(self, data_dir, nthreads=4, ntranscriptionthreads=2, modelDir='exp', contextWidth="3", samplerate=8000):
+    def __init__(self, data_dir, nthreads=4, ntranscriptionthreads=2, modelDir='exp'):
         self.data_dir = data_dir
         self.nthreads = nthreads
         self.ntranscriptionthreads = ntranscriptionthreads
@@ -229,9 +229,8 @@ def serve(port=8765, interface='0.0.0.0', installSignalHandlers=0, nthreads=4, n
     f.putChild('status.html', File(get_resource('www/status.html')))
     f.putChild('preloader.gif', File(get_resource('www/preloader.gif')))
    
-    resources = Resources(modelDir)
-    config = resources.getConfig()
-    trans = Transcriber(data_dir, nthreads=nthreads, ntranscriptionthreads=ntranscriptionthreads, modelDir=modelDir, contextWidth=config['context-width'], samplerate=config['samplerate'])
+    resources = gentle.Resources(modelDir)
+    trans = Transcriber(data_dir, nthreads=nthreads, ntranscriptionthreads=ntranscriptionthreads, modelDir=modelDir)
     trans_ctrl = TranscriptionsController(trans)
     f.putChild('transcriptions', trans_ctrl)
 

--- a/serve.py
+++ b/serve.py
@@ -27,11 +27,12 @@ class TranscriptionStatus(Resource):
         return json.dumps(self.status_dict)
 
 class Transcriber():
-    def __init__(self, data_dir, nthreads=4, ntranscriptionthreads=2):
+    def __init__(self, data_dir, nthreads=4, ntranscriptionthreads=2, modelDir='exp', contextWidth="3", samplerate=8000):
         self.data_dir = data_dir
         self.nthreads = nthreads
         self.ntranscriptionthreads = ntranscriptionthreads
-        self.resources = gentle.Resources()
+        self.resources = gentle.Resources(modelDir)
+        self.config = self.resources.getConfig()
 
         self.full_transcriber = gentle.FullTranscriber(self.resources, nthreads=ntranscriptionthreads)
         self._status_dicts = {}
@@ -70,7 +71,7 @@ class Transcriber():
         status['status'] = 'ENCODING'
 
         wavfile = os.path.join(outdir, 'a.wav')
-        if gentle.resample(os.path.join(outdir, 'upload'), wavfile) != 0:
+        if gentle.resample(os.path.join(outdir, 'upload'), wavfile, self.config['samplerate']) != 0:
             status['status'] = 'ERROR'
             status['error'] = "Encoding failed. Make sure that you've uploaded a valid media file."
             # Save the status so that errors are recovered on restart of the server
@@ -90,7 +91,7 @@ class Transcriber():
                 status[k] = v
 
         if len(transcript.strip()) > 0:
-            trans = gentle.ForcedAligner(self.resources, transcript, nthreads=self.nthreads, **kwargs)
+            trans = gentle.ForcedAligner(self.resources, transcript, nthreads=self.nthreads, context_width=self.config['context-width'], **kwargs)
         elif self.full_transcriber.available:
             trans = self.full_transcriber
         else:
@@ -212,7 +213,7 @@ class TranscriptionZipper(Resource):
         else:
             return Resource.getChild(self, path, req)
 
-def serve(port=8765, interface='0.0.0.0', installSignalHandlers=0, nthreads=4, ntranscriptionthreads=2, data_dir=get_datadir('webdata')):
+def serve(port=8765, interface='0.0.0.0', installSignalHandlers=0, nthreads=4, ntranscriptionthreads=2, data_dir=get_datadir('webdata'), modelDir='exp'):
     logging.info("SERVE %d, %s, %d", port, interface, installSignalHandlers)
 
     if not os.path.exists(data_dir):
@@ -227,8 +228,10 @@ def serve(port=8765, interface='0.0.0.0', installSignalHandlers=0, nthreads=4, n
     f.putChild('', File(get_resource('www/index.html')))
     f.putChild('status.html', File(get_resource('www/status.html')))
     f.putChild('preloader.gif', File(get_resource('www/preloader.gif')))
-
-    trans = Transcriber(data_dir, nthreads=nthreads, ntranscriptionthreads=ntranscriptionthreads)
+   
+    resources = Resources(modelDir)
+    config = resources.getConfig()
+    trans = Transcriber(data_dir, nthreads=nthreads, ntranscriptionthreads=ntranscriptionthreads, modelDir=modelDir, contextWidth=config['context-width'], samplerate=config['samplerate'])
     trans_ctrl = TranscriptionsController(trans)
     f.putChild('transcriptions', trans_ctrl)
 
@@ -259,6 +262,9 @@ if __name__=='__main__':
     parser.add_argument('--log', default="INFO",
                         help='the log level (DEBUG, INFO, WARNING, ERROR, or CRITICAL)')
 
+    parser.add_argument('--model-dir', default='exp',
+                        help='model directory')
+
     args = parser.parse_args()
 
     log_level = args.log.upper()
@@ -267,4 +273,4 @@ if __name__=='__main__':
     logging.info('gentle %s' % (gentle.__version__))
     logging.info('listening at %s:%d\n' % (args.host, args.port))
 
-    serve(args.port, args.host, nthreads=args.nthreads, ntranscriptionthreads=args.ntranscriptionthreads, installSignalHandlers=1)
+    serve(args.port, args.host, nthreads=args.nthreads, ntranscriptionthreads=args.ntranscriptionthreads, installSignalHandlers=1, modelDir=args.model_dir)


### PR DESCRIPTION
This change is to make use of custom models different from provided model. There are two hardcoded parameters stops me from using my model: 
  silence phones - my silence phones are `1:2:3:4:5`. 
  phone context width when building language model. My phone context width is 2 instead of hardcoded 3.
With this change, now it looks for `config.yaml` in model directory. The configuration file is in yaml format. Here is an example: 
```
context-width: 2
samplerate: 16000
silencephones: "1:2:3:4:5"
```

The directory structure is also changed to be more generic. 
- model
  - langdir
  - online
    - graph

this will require changes to the provided example model. 