### PR TITLE
Remove no longer existing kaldi-thread from ADDLIBS

### DIFF
--- a/ext/Makefile
+++ b/ext/Makefile
@@ -15,7 +15,7 @@ ADDLIBS = $(KALDI_BASE)online2/kaldi-online2.a $(KALDI_BASE)ivector/kaldi-ivecto
           $(KALDI_BASE)nnet2/kaldi-nnet2.a $(KALDI_BASE)lat/kaldi-lat.a \
           $(KALDI_BASE)decoder/kaldi-decoder.a  $(KALDI_BASE)cudamatrix/kaldi-cudamatrix.a \
           $(KALDI_BASE)feat/kaldi-feat.a $(KALDI_BASE)transform/kaldi-transform.a $(KALDI_BASE)gmm/kaldi-gmm.a \
-          $(KALDI_BASE)thread/kaldi-thread.a $(KALDI_BASE)hmm/kaldi-hmm.a $(KALDI_BASE)tree/kaldi-tree.a \
+          $(KALDI_BASE)hmm/kaldi-hmm.a $(KALDI_BASE)tree/kaldi-tree.a \
           $(KALDI_BASE)matrix/kaldi-matrix.a $(KALDI_BASE)fstext/kaldi-fstext.a \
           $(KALDI_BASE)util/kaldi-util.a $(KALDI_BASE)base/kaldi-base.a
 


### PR DESCRIPTION
Commit: https://github.com/lowerquality/gentle/commit/49e919518f2768acf34845e82724e6f7e5173a3d
updated Kaldi to the newest version which does not have kaldi-thread anymore. 
Having it here leads to the compilation failure.

[Issue]
Ad-hoc fix