### PR TITLE
Set bufsize=0 in Popen to avoid buffer issues on stdin.write()

### DIFF
--- a/gentle/standard_kaldi.py
+++ b/gentle/standard_kaldi.py
@@ -21,7 +21,7 @@ class Kaldi:
             logger.error('hclg_path does not exist: %s', hclg_path)
         self._p = subprocess.Popen(cmd,
                                    stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-                                   stderr=STDERR)
+                                   stderr=STDERR, bufsize=0)
         self.finished = False
 
     def _cmd(self, c):


### PR DESCRIPTION
This resolves #186 for us, though it’s a small sample size of tests. Proposing as a simpler alternative to #196.