### PR TITLE
Fix CI syntax failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ script:
 after_success:
   - if [ "$TRAVIS_BRANCH" == "master" ]; then
     docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
-    docker push lowerquality/gentle:latest
+    docker push lowerquality/gentle:latest;
     fi


### PR DESCRIPTION
The last stage of the CI is missing a `;` which is causing the project failing to be pushed to Docker Hub.

Fix tested with https://hub.docker.com/r/cnbeining/gentle .