### PR TITLE
don't fail if brew packages already installed

### DIFF
--- a/install_deps.sh
+++ b/install_deps.sh
@@ -13,6 +13,13 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
 	apt-get install -y ffmpeg || echo -n  "\n\nYou have to install ffmpeg from a PPA or from https://ffmpeg.org before you can run gentle\n\n"
 	python3 setup.py develop
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-	brew install ffmpeg libtool automake autoconf wget python3
+	brew bundle --no-upgrade --file=- <<-EOS
+		brew "ffmpeg"
+		brew "libtool"
+		brew "automake"
+		brew "autoconf"
+		brew "wget"
+		brew "python3"
+EOS
 	sudo python3 setup.py develop
 fi


### PR DESCRIPTION
got bit by this problem when installing, mentioned here: https://github.com/lowerquality/gentle/issues/128

the solution suggested by a brew maintainer is to use `brew bundle` instead of `brew install`: https://github.com/Homebrew/brew/issues/2491#issuecomment-372402005

I added `--no-upgrade` since bundle wants to upgrade the packages if they’re already installed.  Remove that if you like.