### PR TITLE
Fix compilation errors for modern kaldi/openfst

### DIFF
--- a/ext/k3.cc
+++ b/ext/k3.cc
@@ -15,6 +15,9 @@
 #include "cudamatrix/cu-device.h"
 #endif
 
+#include <string>
+using std::string;
+
 const int arate = 8000;
 
 void ConfigFeatureInfo(kaldi::OnlineNnet2FeaturePipelineInfo& info,
@@ -96,10 +99,7 @@ int main(int argc, char *argv[]) {
 
 #ifdef HAVE_CUDA
     fprintf(stdout, "Cuda enabled\n");
-    CuDevice &cu_device = CuDevice::Instantiate();
-    cu_device.SetVerbose(true);
-    cu_device.SelectGpuId("yes");
-    fprintf(stdout, "active gpu: %d\n", cu_device.ActiveGpuId());
+    CuDevice::Instantiate().SelectGpuId("yes");
 #endif
     const std::string ivector_model_dir = nnet_dir + "/ivector_extractor";
     const std::string nnet3_rxfilename = nnet_dir + "/final.mdl";

--- a/ext/m3.cc
+++ b/ext/m3.cc
@@ -9,6 +9,7 @@
 #include "util/common-utils.h"
 #include <fst/script/arcsort.h>
 #include <fst/script/compile.h>
+#include <fst/symbol-table.h>
 
 int main(int argc, char *argv[]) {
 	using namespace kaldi;
@@ -65,11 +66,10 @@ int main(int argc, char *argv[]) {
 		}
 
 		// fstcompile
-		const SymbolTable *ssyms = 0;
-		fst::SymbolTableTextOptions opts;
-		const SymbolTable *isyms = SymbolTable::ReadText(words_filename, opts);
+		SymbolTable *ssyms = 0;
+		fst::SymbolTable *isyms = fst::SymbolTable::ReadText(words_filename);
 		if (!isyms) { return 1; }
-		const SymbolTable *osyms = SymbolTable::ReadText(words_filename, opts);
+		fst::SymbolTable *osyms = fst::SymbolTable::ReadText(words_filename);
 		if (!osyms) { return 1; }
 		std::ifstream grammar_fst_file(grammar_fst_filename.c_str());
 		FstCompiler<StdArc> fstcompiler(grammar_fst_file, "", isyms,


### PR DESCRIPTION
Fixes #353

- Update kaldi submodule to latest (fixes Python 2.7 requirement, bumps openfst to 1.8.4)
- Fix ext/k3.cc: add missing string include, remove non-existent CUDA methods
- Fix ext/m3.cc: update SymbolTable API for openfst 1.8.x